### PR TITLE
Fix issue with new TPV FIT file structure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fit-file-faker"
-version = "1.2.1"
+version = "1.2.2"
 description = "A small tool to edit and upload FIT files to Garmin Connect"
 authors = [
   { name="Josh Taillon", email="jat255@gmail.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -71,7 +71,7 @@ wheels = [
 
 [[package]]
 name = "fit-file-faker"
-version = "0.2.0"
+version = "1.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "fit-tool" },


### PR DESCRIPTION
Fixes #22 

Issue was due to how the `FileIdMessage` was generated by TPV during a structured workout (compared to a free ride)

Changes:
- Change to generate FileIdMessage rather than editing in place to ensure device is properly set
- Also add FileCreator message (not sure if required)
- Bump version