### PR TITLE
Add support for Hammerhead Karoo to Garmin Edge 830 device change

### DIFF
--- a/app.py
+++ b/app.py
@@ -228,7 +228,8 @@ def rewrite_file_id_message(
         m.manufacturer == Manufacturer.DEVELOPMENT.value or 
         m.manufacturer == Manufacturer.ZWIFT.value or 
         m.manufacturer == Manufacturer.WAHOO_FITNESS.value or 
-        m.manufacturer == Manufacturer.PEAKSWARE.value
+        m.manufacturer == Manufacturer.PEAKSWARE.value or 
+        m.manufacturer == Manufacturer.HAMMERHEAD.value
     ):
         new_m.manufacturer = Manufacturer.GARMIN.value
         new_m.product = GarminProduct.EDGE_830.value
@@ -290,7 +291,8 @@ def edit_fit(
                     message.manufacturer == 0 or
                     message.manufacturer == Manufacturer.WAHOO_FITNESS.value or
                     message.manufacturer == Manufacturer.ZWIFT.value or
-                    message.manufacturer == Manufacturer.PEAKSWARE.value
+                    message.manufacturer == Manufacturer.PEAKSWARE.value or 
+                    message.manufacturer == Manufacturer.HAMMERHEAD.value
                 ):
                     _logger.debug("    Modifying values")
                     message.garmin_product = GarminProduct.EDGE_830.value


### PR DESCRIPTION
Hello,

First of all, thank you for this excellent project! I found it very useful and decided to contribute back by adding support for the Hammerhead Karoo device.

This PR introduces modification of the device name to Garmin Edge 830 when uploading Hammerhead Karoo activities. Without this change, Hammerhead Karoo activity uploads function correctly, but the device name remains unchanged.

Please let me know if there's anything more you'd like adjusted or enhanced.

Thanks again for maintaining this great tool!