### PR TITLE
added ability to work with MyWhoosh fit files

### DIFF
--- a/app.py
+++ b/app.py
@@ -229,7 +229,8 @@ def rewrite_file_id_message(
         m.manufacturer == Manufacturer.ZWIFT.value or 
         m.manufacturer == Manufacturer.WAHOO_FITNESS.value or 
         m.manufacturer == Manufacturer.PEAKSWARE.value or 
-        m.manufacturer == Manufacturer.HAMMERHEAD.value
+        m.manufacturer == Manufacturer.HAMMERHEAD.value or
+        m.manufacturer == 331 # MYWHOOSH is unknown to fit_tools
     ):
         new_m.manufacturer = Manufacturer.GARMIN.value
         new_m.product = GarminProduct.EDGE_830.value
@@ -292,7 +293,8 @@ def edit_fit(
                     message.manufacturer == Manufacturer.WAHOO_FITNESS.value or
                     message.manufacturer == Manufacturer.ZWIFT.value or
                     message.manufacturer == Manufacturer.PEAKSWARE.value or 
-                    message.manufacturer == Manufacturer.HAMMERHEAD.value
+                    message.manufacturer == Manufacturer.HAMMERHEAD.value or
+                    message.manufacturer == 331  # MYWHOOSH is unknown to fit_tools
                 ):
                     _logger.debug("    Modifying values")
                     message.garmin_product = GarminProduct.EDGE_830.value


### PR DESCRIPTION
* MyWhoosh changed the manufacturer from GARMIN (Edge 1030 Plus) to MYWHOOSH about a week ago (should also solve https://github.com/jat255/Fit-File-Faker/issues/31)
* unfortunately this is unknown to fit_tools which needs an additional matching of MYWHOOSH = 331 inside the profile_type.py, but the project seems to be unmaintained for 3 years, so the quick win for this should be to use the id directly

Resolves #31 