### PR TITLE
mywhoosh: add file hash to .uploaded_files.json

### DIFF
--- a/fit_file_faker/app.py
+++ b/fit_file_faker/app.py
@@ -33,6 +33,7 @@ from importlib.metadata import version
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Optional, cast
+from hashlib import sha256
 
 import questionary
 import semver
@@ -396,21 +397,29 @@ def upload_all(
     for f in files:
         _logger.info(f'Processing "{f}"')  # type: ignore
 
+        f_path = dir.joinpath(f)
+
+        h265 = sha256()
+        h265.update(open(f_path, "rb").read())
+        f_hash = h265.hexdigest()
+
         if not preinitialize:
             with NamedTemporaryFile(delete=True, delete_on_close=False) as fp:
                 fit_editor.set_profile(profile)
-                output = fit_editor.edit_fit(dir.joinpath(f), output=Path(fp.name))
+                output = fit_editor.edit_fit(f_path, output=Path(fp.name))
                 if output:
                     _logger.info("Uploading modified file to Garmin Connect")
                     upload(
                         output, profile=profile, original_path=Path(f), dryrun=dryrun
                     )
-                    _logger.debug(f'Adding "{f}" to "uploaded_files"')
+                    _logger.debug(
+                        f'Adding "{f}" with hash "{f_hash}" to "uploaded_files"'
+                    )
         else:
             _logger.info(
                 "Preinitialize was requested, so just marking as uploaded (not actually processing)"
             )
-        uploaded_files.append(f)
+        uploaded_files.append(f"{f}-{f_hash}")
 
     if not dryrun:
         with files_uploaded.open("w") as f:

--- a/fit_file_faker/app.py
+++ b/fit_file_faker/app.py
@@ -233,12 +233,19 @@ class NewFileEventHandler(PatternMatchingEventHandler):
                             with uploaded_list.open("r") as f:
                                 uploaded_files = json.load(f)
 
-                        filename = source_file.name
-                        if filename not in uploaded_files:
-                            uploaded_files.append(filename)
+                        file = {
+                            "name": source_file.name,
+                            "hash": sha256(
+                                open(dir.joinpath(source_file.name), "rb").read()
+                            ).hexdigest(),
+                        }
+                        if file not in uploaded_files:
+                            uploaded_files.append(file)
                             with uploaded_list.open("w") as f:
                                 json.dump(uploaded_files, f, indent=2)
-                            _logger.debug(f'Added "{filename}" to uploaded files list')
+                            _logger.debug(
+                                f'Added "{file["name"]}" with hash "{file["hash"]}" to uploaded files list'
+                            )
             else:
                 _logger.warning(
                     "Found modified file, but not processing because dryrun was requested"
@@ -385,6 +392,11 @@ def upload_all(
     files = [i.replace(str(dir), "").strip("/").strip("\\") for i in files]
     # remove files matching what we may have already processed
     files = [i for i in files if not i.endswith("_modified.fit")]
+    # append file hash for each file
+    files = [
+        {"name": i, "hash": sha256(open(dir.joinpath(i), "rb").read()).hexdigest()}
+        for i in files
+    ]
     # remove files found in the "already uploaded" list
     files = [i for i in files if i not in uploaded_files]
 
@@ -395,13 +407,9 @@ def upload_all(
         return
 
     for f in files:
-        _logger.info(f'Processing "{f}"')  # type: ignore
+        _logger.info(f'Processing "{f["name"]}"')  # type: ignore
 
-        f_path = dir.joinpath(f)
-
-        h265 = sha256()
-        h265.update(open(f_path, "rb").read())
-        f_hash = h265.hexdigest()
+        f_path = dir.joinpath(f["name"])
 
         if not preinitialize:
             with NamedTemporaryFile(delete=True, delete_on_close=False) as fp:
@@ -410,16 +418,19 @@ def upload_all(
                 if output:
                     _logger.info("Uploading modified file to Garmin Connect")
                     upload(
-                        output, profile=profile, original_path=Path(f), dryrun=dryrun
+                        output,
+                        profile=profile,
+                        original_path=Path(f["name"]),
+                        dryrun=dryrun,
                     )
                     _logger.debug(
-                        f'Adding "{f}" with hash "{f_hash}" to "uploaded_files"'
+                        f'Adding "{f["name"]}" with hash "{f["hash"]}" to "uploaded_files"'
                     )
         else:
             _logger.info(
                 "Preinitialize was requested, so just marking as uploaded (not actually processing)"
             )
-        uploaded_files.append(f"{f}-{f_hash}")
+        uploaded_files.append(f)
 
     if not dryrun:
         with files_uploaded.open("w") as f:


### PR DESCRIPTION
**Problem**
When uploading activities with `fit-file-faker -ua` only the first MyWhoosh activity is uploaded. Subsequent activity uploads are removed from the list of FIT files here https://github.com/jat255/Fit-File-Faker/blob/main/fit_file_faker/app.py#L387-L388 and therefore skipped.

This is because MyWhoosh does not store FIT files with a unique name but one per app version which overwrites previous FIT files:
```
 % ls -1 ~/Library/Containers/com.whoosh.whooshgame/Data/Library/Application\ Support/Epic/MyWhoosh/Content/Data/*.fit
MyNewActivity-5.6.1.fit
MyNewActivity-5.7.0.fit
MyNewActivity-5.7.1.fit
```

**Fix**
Instead of pushing the FIT filename to `FILES_UPLOADED_NAME` only, this PR adds objects per uploaded FIT file including a hash of the FIT file content.
```
[
  {
    "name": "MyNewActivity-5.6.1.fit",
    "hash": "7606e6afe7504d5c5e5737e5c5f47088976239dca9f757e8bb0f0a15c4ce4975"
  },
  {
    "name": "MyNewActivity-5.6.1.fit",
    "hash": "e2b3d2e0a1cc0ad2c855eeb58799ebbbbc4dc4c1df6b00f276e9a60a503013d8"
  },
  {
    "name": "MyNewActivity-5.7.0.fit",
    "hash": "c71376c2096b18deac1a4c462a6ee6900198a364a1161700707087908b5097a0"
  },
  {
    "name": "MyNewActivity-5.7.1.fit",
    "hash": "749e98409e26eacf76cc9d0964d873a6be149a486c4e98f385473b2715b7e76b"
  },
  {
    "name": "MyNewActivity-5.7.1.fit",
    "hash": "76bc00f4eca9026502f3c974bf4b3ab10efc57ef1092f10ff75b609be46035dc"
  }
] 
```