### PR TITLE
feat: replace garth with garminconnect for Garmin Connect uploads

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ fit_file_faker/
 3. **Identify device messages**: Locates `FileIdMessage`, `FileCreatorMessage`, and `DeviceInfoMessage` records
 4. **Rewrite manufacturer/product IDs**: Changes manufacturer codes from DEVELOPMENT (255), ZWIFT, WAHOO_FITNESS, PEAKSWARE, HAMMERHEAD, COROS, or MYWHOOSH (331) to GARMIN (1) with Edge 830 product ID (3122)
 5. **Rebuild FIT file**: Uses `FitFileBuilder` to reconstruct the file with modified messages
-6. **Upload (optional)**: Authenticates to Garmin Connect via `garth` library and uploads the modified file
+6. **Upload (optional)**: Authenticates to Garmin Connect via `python-garminconnect` library and uploads the modified file
 
 ### Module Breakdown
 
@@ -111,7 +111,7 @@ fit_file_faker/
 - `ConfigManager`: Handles config file I/O, validation, auto-migration from v1.2.4 format
 - `ProfileManager`: CRUD operations for profile management (create, read, update, delete, set_default)
 - `migrate_legacy_config()`: Auto-converts single-profile configs to multi-profile format
-- `get_garth_dir(profile_name)`: Profile-specific credential isolation
+- `get_token_dir(profile_name)`: Profile-specific token directory isolation
 - Stored in platform-specific user config directory (via `platformdirs`) as `.config.json`
 - **Auto-detection**: Platform-specific directory detection for TPV, Zwift, MyWhoosh via `app_registry.py`
 - **TUI**: Rich-based interactive menu system for profile management
@@ -149,11 +149,11 @@ fit_file_faker/
 - CLI argument parsing and validation
 - **Multi-Profile Support**: `--profile/-p`, `--list-profiles`, `--config-menu` arguments
 - `select_profile()`: Profile selection logic (arg → default → prompt)
-- `upload()`: Garmin Connect upload with OAuth authentication via `garth` (now accepts `Profile` parameter)
+- `upload()`: Garmin Connect upload with OAuth authentication via `python-garminconnect` (accepts `Profile` parameter)
 - `upload_all()`: Batch processes all FIT files in a directory (profile-aware)
 - `monitor()`: Watches directory for new FIT files using `watchdog` (profile-specific)
 - `NewFileEventHandler`: Event handler for monitoring mode (uses profile)
-- Credentials cached in profile-specific cache directories (`.garth_{profile_name}` folders)
+- Tokens cached in profile-specific data directories (`.garmin_{profile_name}` folders)
 - Handles HTTP 409 conflicts (duplicate activities) gracefully
 - Maintains `.uploaded_files.json` to track processed files
 
@@ -202,7 +202,7 @@ The tool recognizes and modifies FIT files from:
 - `RichHandler` for colored, timestamped logs
 - Custom `FitFileLogFilter` in `fit_editor.py` to suppress fit_tool's "actual:" warnings
 - Debug mode (`-v`) provides detailed message-by-message processing logs
-- Separate loggers for different modules (urllib3, oauth1_auth, watchdog, etc.)
+- Separate loggers for different modules (urllib3, watchdog, etc.)
 
 ## Important Implementation Notes
 
@@ -358,7 +358,7 @@ Coverage reports are uploaded to Codecov on successful Ubuntu + Python 3.12 runs
 ### Test Features
 
 - ✅ **Complete isolation**: All tests use temporary directories (no real config touched)
-- ✅ **Mocked services**: Garmin Connect (`garth`) and user prompts (`questionary`)
+- ✅ **Mocked services**: Garmin Connect (`garminconnect`) and user prompts (`questionary`)
 - ✅ **Shared fixtures**: `conftest.py` provides reusable fixtures to reduce duplication
 - ✅ **Platform coverage**: Tests run on all supported platforms (TPV, Zwift, MyWhoosh, Karoo, COROS)
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -151,7 +151,7 @@ The tool follows a six-step process:
     to `GARMIN` (1) with Edge 830 product ID (3122)
 
 5. **Rebuild FIT file**: Uses `FitFileBuilder` to reconstruct the file with modified messages
-6. **Upload (optional)**: Authenticates to Garmin Connect via `garth` library and uploads the modified file
+6. **Upload (optional)**: Authenticates to Garmin Connect via `python-garminconnect` library and uploads the modified file
 
 ### Module Breakdown
 
@@ -196,7 +196,7 @@ The tool follows a six-step process:
 
 **Utilities**:
 
-- `get_garth_dir(profile_name)`: Profile-specific credential isolation
+- `get_token_dir(profile_name)`: Profile-specific token directory isolation
 - `PathEncoder`: Custom JSON encoder for Path and Enum objects
 - Stored in platform-specific user config directory (via `platformdirs`) as `.config.json`
 - Auto-detection via `app_registry.py` for TPV, Zwift, MyWhoosh directories
@@ -384,9 +384,9 @@ Firmware versions should be periodically updated to reflect latest stable releas
     - `--list-profiles`: Display all configured profiles
     - `--config-menu`: Launch interactive profile management
 - `select_profile()`: Profile selection logic (arg → default → prompt)
-- `upload()`: Garmin Connect upload with OAuth authentication via `garth` (now accepts `Profile` parameter)
-    - Handles authentication and credential prompting
-    - Caches credentials in profile-specific `.garth_{profile_name}` directories
+- `upload()`: Garmin Connect upload with OAuth authentication via `python-garminconnect` (accepts `Profile` parameter)
+    - Authenticates using `Garmin.login(tokenstore=...)` with automatic token caching
+    - Tokens cached in profile-specific `.garmin_{profile_name}` directories under `user_data_path`
     - Gracefully handles HTTP 409 conflicts (duplicate activities)
 - `upload_all()`: Batch processes all FIT files in a directory (profile-aware)
     - Maintains `.uploaded_files.json` to track processed files
@@ -423,7 +423,7 @@ The tool recognizes and modifies FIT files from:
 - `RichHandler` for colored, timestamped logs with traceback support
 - Custom `FitFileLogFilter` in `fit_editor.py` to suppress fit_tool's "actual:" warnings
 - Debug mode (`-v`) provides detailed message-by-message processing logs
-- Separate log level configuration for different modules (urllib3, oauth1_auth, watchdog, asyncio, etc.)
+- Separate log level configuration for different modules (urllib3, watchdog, asyncio, etc.)
 
 
 ## 📚 Extensibility
@@ -603,13 +603,10 @@ The test suite uses shared fixtures in `conftest.py` to reduce duplication:
 #### Shared Mock Classes
 
 - **`MockQuestion`**: Mock for questionary interactive prompts
-- **`MockGarthHTTPError`**: Configurable HTTP error mock with status codes
-- **`MockGarthException`**: Standard Garth exception for auth flow testing
 
 #### Shared Fixtures
 
-- **`mock_garth_basic`**: Basic Garmin Connect mock for successful operations
-- **`mock_garth_with_login`**: Garmin mock requiring authentication
+- **`mock_garmin_client`**: Mocks `garminconnect.Garmin` for upload tests (patches `fit_file_faker.app.Garmin`)
 - **`isolate_config_dirs`** (autouse): Automatically isolates all tests from real user directories
 - **`temp_dir`**: Creates temporary directories for test outputs
 - **`mock_config_file`**: Creates mock configuration files
@@ -618,12 +615,9 @@ The test suite uses shared fixtures in `conftest.py` to reduce duplication:
 
 #### External Services
 
-- **Garmin Connect** (`garth`): Mocked using `sys.modules` patching with shared fixtures
+- **Garmin Connect** (`garminconnect`): Mocked by patching `fit_file_faker.app.Garmin` at the class level via `mock_garmin_client` fixture
 - **User prompts** (`questionary`): Mocked using `MockQuestion` helper class
 - **File system** (`platformdirs`): Automatically redirected to temp directories via `isolate_config_dirs`
-
-!!! note "Why sys.modules for garth?"
-    The `garth` library is imported inside functions (lazy import), so we use `patch.dict('sys.modules')` to inject mock modules that get imported at runtime.
 
 ### Running Tests
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@
 
 </div>
 
-This application allows you to easily modify [FIT](https://developer.garmin.com/fit/overview/) files to make them appear to come from a Garmin device (70+ modern devices supported, including Edge 1050, Fenix 8, Forerunner 965, and more) and upload them to Garmin Connect using the [`garth`](https://github.com/matin/garth/) library. The FIT editing is done using Stages Cycling's [`fit_tool`](https://bitbucket.org/stagescycling/python_fit_tool/src/main/) library.
+This application allows you to easily modify [FIT](https://developer.garmin.com/fit/overview/) files to make them appear to come from a Garmin device (70+ modern devices supported, including Edge 1050, Fenix 8, Forerunner 965, and more) and upload them to Garmin Connect using the [`python-garminconnect`](https://github.com/cyberjunky/python-garminconnect) library. The FIT editing is done using Stages Cycling's [`fit_tool`](https://bitbucket.org/stagescycling/python_fit_tool/src/main/) library.
 
 !!! support "Support This Project"
     If FIT File Faker saves you time or enhances your training workflow, consider [buying me a coffee ☕](https://ko-fi.com/josh851356). Your support helps maintain and improve this project!
@@ -379,9 +379,9 @@ fit-file-faker --show-dirs
 
 #### Credential Isolation
 
-Each profile has isolated Garmin credentials stored in profile-specific directories:
-- `.garth_tpv/` for TPV profile
-- `.garth_zwift/` for Zwift profile
+Each profile has isolated Garmin tokens stored in profile-specific directories:
+- `.garmin_tpv/` for TPV profile
+- `.garmin_zwift/` for Zwift profile
 - etc.
 
 ### Verbose Output
@@ -406,8 +406,8 @@ Example output:
            DEBUG        Modifying values                                                     app.py:97
            DEBUG        New Record: 14 - manufacturer: 1 ("GARMIN") - product: 3122 - garmin app.py:55
                     product: 3122 ("GarminProduct.EDGE_830")
-[12:38:34] DEBUG    Using stored Garmin credentials from ".garth" directory                 app.py:118
-[12:38:35] INFO     ✅ Successfully uploaded "path_to_file.fit"                             app.py:137
+[12:38:34] INFO     Authenticating to Garmin Connect                                         app.py:295
+[12:38:35] INFO     ✅ Successfully uploaded "path_to_file.fit"                             app.py:313
 ```
 
 ### "Upload All" and "Monitor" Modes
@@ -445,7 +445,7 @@ $ fit-file-faker --monitor /home/user/Documents/TPVirtual/0123456789ABCEDF/FITFi
 [14:03:58] INFO     Activity timestamp is "2025-01-03T17:01:45"                    app.py:223
 [14:03:59] INFO     Saving modified data to "/tmp/tmpsn4gvpkh"                     app.py:250
 [14:04:00] INFO     Uploading modified file to Garmin Connect                      app.py:346
-[14:04:01] INFO     Uploading "/tmp/tmpsn4gvpkh" using garth                       app.py:295
+[14:04:01] INFO     Uploading "/tmp/tmpsn4gvpkh" to Garmin Connect                  app.py:303
 ^C[14:04:46] INFO     Received keyboard interrupt, shutting down monitor           app.py:372
 ```
 

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -228,17 +228,17 @@ For unsupported trainer apps or custom setups:
 
 Each profile has its own isolated Garmin authentication:
 
-- **Garth directories**: `/Users/test/Library/Caches/FitFileFaker/.garth_{profile_name}/`
+- **Token directories**: `/Users/test/Library/Application Support/FitFileFaker/.garmin_{profile_name}/`
 - **Separate OAuth tokens**: No credential sharing between profiles
 - **Secure storage**: Platform-specific storage via `platformdirs`
 
 ### Example Directory Structure
 
 ```
-/Users/test/Library/Caches/FitFileFaker
-├── .garth_tpv/          # TPV profile credentials
-├── .garth_zwift/        # Zwift profile credentials
-└── .garth_mywhoosh/     # MyWhoosh profile credentials
+/Users/test/Library/Application Support/FitFileFaker
+├── .garmin_tpv/          # TPV profile tokens
+├── .garmin_zwift/        # Zwift profile tokens
+└── .garmin_mywhoosh/     # MyWhoosh profile tokens
 ```
 
 ## Configuration File

--- a/fit_file_faker/app.py
+++ b/fit_file_faker/app.py
@@ -58,7 +58,11 @@ logging.basicConfig(
 )
 _logger.setLevel(logging.INFO)
 logging.getLogger("urllib3.connectionpool").setLevel(logging.WARNING)
-logging.getLogger("oauth1_auth").setLevel(logging.WARNING)
+
+from garminconnect import (
+    Garmin,
+    GarminConnectConnectionError,
+)
 
 from . import __version_date__
 from .config import config_manager, dirs, profile_manager, Profile
@@ -72,34 +76,28 @@ c = Console()
 FILES_UPLOADED_NAME = Path(".uploaded_files.json")
 
 
-def get_garth_dir(profile_name: str) -> Path:
-    """Get profile-specific garth directory for credential isolation.
+def get_token_dir(profile_name: str) -> Path:
+    """Get profile-specific token directory for credential isolation.
 
-    Each profile gets its own garth directory to prevent credential conflicts
+    Each profile gets its own token directory to prevent credential conflicts
     when managing multiple Garmin accounts. The profile name is sanitized to
-    ensure filesystem compatibility.
+    ensure filesystem compatibility. Tokens are stored under user_data_path
+    (not cache) so they survive routine cache wipes.
 
     Args:
         profile_name: The name of the profile.
 
     Returns:
-        Path to the profile-specific garth directory.
-
-    Examples:
-        >>> get_garth_dir("tpv")
-        PosixPath('/Users/josh/Library/Caches/FitFileFaker/.garth_tpv')
-        >>>
-        >>> get_garth_dir("work-account")
-        PosixPath('/Users/josh/Library/Caches/FitFileFaker/.garth_work-account')
+        Path to the profile-specific token directory.
 
     Note:
         The directory is automatically created if it doesn't exist.
         Profile names with special characters are sanitized (replaced with '_').
     """
     safe_name = "".join(c if c.isalnum() or c in "-_" else "_" for c in profile_name)
-    garth_dir = dirs.user_cache_path / f".garth_{safe_name}"
-    garth_dir.mkdir(exist_ok=True, parents=True)
-    return garth_dir
+    token_dir = dirs.user_data_path / f".garmin_{safe_name}"
+    token_dir.mkdir(exist_ok=True, parents=True)
+    return token_dir
 
 
 class NewFileEventHandler(PatternMatchingEventHandler):
@@ -253,8 +251,8 @@ def upload(
     """Upload a FIT file to Garmin Connect.
 
     Authenticates to Garmin Connect using credentials from the specified profile,
-    then uploads the specified FIT file. Credentials are cached in a profile-specific
-    cache directory for future use.
+    then uploads the specified FIT file. Tokens are cached in a profile-specific
+    data directory for future use.
 
     Args:
         fn: Path to the (modified) FIT file to upload.
@@ -265,8 +263,9 @@ def upload(
             Defaults to `False`.
 
     Raises:
-        GarthHTTPError: If upload fails with an HTTP error. 409 (conflict/duplicate)
-            errors are caught and logged as warnings, but other HTTP errors are re-raised.
+        ValueError: If the profile is missing Garmin credentials.
+        GarminConnectConnectionError: If upload fails with an HTTP error other than 409.
+            409 (conflict/duplicate) errors are caught and logged as warnings.
 
     Examples:
         >>> from pathlib import Path
@@ -277,58 +276,41 @@ def upload(
         >>> upload(Path("activity_modified.fit"), profile=my_profile, dryrun=True)
 
     Note:
-        Garmin Connect credentials are read from the profile. Credentials are cached
-        in profile-specific directories like ~/.cache/FitFileFaker/.garth_<profile_name>
+        Garmin Connect credentials are read from the profile. Tokens are cached in
+        profile-specific directories like ~/Library/Application Support/FitFileFaker/.garmin_<profile_name>
         (location varies by platform).
     """
-    # get credentials and login if needed
-    import garth
-    from garth.exc import GarthException, GarthHTTPError
+    token_dir = get_token_dir(profile.name)
+    _logger.debug(f'Using "{token_dir}" for Garmin token storage')
 
-    garth_dir = get_garth_dir(profile.name)
-    _logger.debug(f'Using "{garth_dir}" for garth credentials')
+    email = profile.garmin_username
+    password = profile.garmin_password
+    if not email or not password:
+        raise ValueError(
+            f'Profile "{profile.name}" is missing Garmin credentials. '
+            "Run with --config-menu to update the profile."
+        )
 
-    try:
-        garth.resume(str(garth_dir.absolute()))
-        garth.client.username
-        _logger.debug(f'Using stored Garmin credentials from "{garth_dir}" directory')
-    except (GarthException, FileNotFoundError):
-        # Session is expired. You'll need to log in again
-        _logger.info("Authenticating to Garmin Connect")
-        email = profile.garmin_username
-        password = profile.garmin_password
-        if not email:
-            email = questionary.text(
-                'No "garmin_username" variable set; Enter email address: '
-            ).ask()
-        _logger.debug(f'Using username "{email}"')
-        if not password:
-            password = questionary.password(
-                'No "garmin_password" variable set; Enter password: '
-            ).ask()
-            _logger.debug("Using password from user input")
-        else:
-            _logger.debug('Using password stored in "garmin_password"')
-        garth.login(email, password)
-        garth.save(str(garth_dir.absolute()))
+    client = Garmin(email, password)
+    _logger.info("Authenticating to Garmin Connect")
+    client.login(tokenstore=str(token_dir))
 
-    with fn.open("rb") as f:
+    if not dryrun:
         try:
-            if not dryrun:
-                _logger.info(f'Uploading "{fn}" using garth')
-                garth.client.upload(f)
-                _logger.info(
-                    f':white_check_mark: Successfully uploaded "{str(original_path)}"'
-                )
-            else:
-                _logger.info(f'Skipping upload of "{fn}" because dryrun was requested')
-        except GarthHTTPError as e:
-            if e.error.response.status_code == 409:
+            _logger.info(f'Uploading "{fn}" to Garmin Connect')
+            client.upload_activity(str(fn))
+            _logger.info(
+                f':white_check_mark: Successfully uploaded "{str(original_path)}"'
+            )
+        except GarminConnectConnectionError as e:
+            if "409" in str(e):
                 _logger.warning(
                     f':x: Received HTTP conflict (activity already exists) for "{str(original_path)}"'
                 )
             else:
-                raise e
+                raise
+    else:
+        _logger.info(f'Skipping upload of "{fn}" because dryrun was requested')
 
 
 def upload_all(
@@ -719,15 +701,20 @@ def run():
             f'\n[green]Cache directory:[/green] [yellow]"{config_dirs.user_cache_path}"[/yellow]'
         )
 
-        # Find and list actual .garth directories
-        garth_dirs = sorted(config_dirs.user_cache_path.glob(".garth_*"))
-        if garth_dirs:
-            console.print("  [dim]Garmin credential directories:[/dim]")
-            for garth_dir in garth_dirs:
-                console.print(f'    [yellow]"{garth_dir}"[/yellow]')
+        # Show data directory and token directories
+        console.print(
+            f'\n[green]Data directory:[/green] [yellow]"{config_dirs.user_data_path}"[/yellow]'
+        )
+
+        # Find and list actual .garmin token directories
+        garmin_dirs = sorted(config_dirs.user_data_path.glob(".garmin_*"))
+        if garmin_dirs:
+            console.print("  [dim]Garmin token directories:[/dim]")
+            for garmin_dir in garmin_dirs:
+                console.print(f'    [yellow]"{garmin_dir}"[/yellow]')
         else:
             console.print(
-                "  [dim]No Garmin credential directories found (will be created on first use)[/dim]"
+                "  [dim]No Garmin token directories found (will be created on first use)[/dim]"
             )
 
         console.print()

--- a/fit_file_faker/config.py
+++ b/fit_file_faker/config.py
@@ -625,7 +625,7 @@ class Profile:
     Garmin Connect credentials.
 
     Attributes:
-        name: Unique profile identifier (used for display and garth dir naming)
+        name: Unique profile identifier (used for display and garmin token dir naming)
         app_type: Type of trainer app (for auto-detection and validation)
         garmin_username: Garmin Connect account email address
         garmin_password: Garmin Connect account password

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,14 +14,14 @@ classifiers = [
 ]
 
 dependencies = [
-    "garth>=0.5.21",
+    "garminconnect>=0.3.3",
     "platformdirs>=4.5.1",
     "questionary>=2.1.1",
     "rich>=14.2.0",
     "semver>=3.0.4",
     "watchdog>=6.0.0",
     "bitstruct==8.11.1",
-    "openpyxl==2.5.12"
+    "openpyxl==2.5.12",
 ]
 
 [dependency-groups]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,14 +25,17 @@ def isolate_config_dirs(monkeypatch, tmp_path):
     """
     config_dir = tmp_path / "config"
     cache_dir = tmp_path / "cache"
+    data_dir = tmp_path / "data"
     config_dir.mkdir()
     cache_dir.mkdir()
+    data_dir.mkdir()
 
     # Create a mock PlatformDirs class
     class MockPlatformDirs:
         def __init__(self, *args, **kwargs):
             self.user_config_path = config_dir
             self.user_cache_path = cache_dir
+            self.user_data_path = data_dir
 
     # Patch platformdirs in both config and app modules
     monkeypatch.setattr("fit_file_faker.config.PlatformDirs", MockPlatformDirs)
@@ -251,50 +254,19 @@ class MockQuestion:
         return self.return_value
 
 
-class MockGarthHTTPError(Exception):
-    """Mock Garth HTTP error with configurable status code."""
-
-    def __init__(self, status_code=500):
-        from unittest.mock import MagicMock
-
-        self.error = MagicMock()
-        self.error.response.status_code = status_code
-
-
-class MockGarthException(Exception):
-    """Mock Garth exception for testing authentication flows."""
-
-    pass
-
-
 @pytest.fixture
-def mock_garth_basic():
-    """Create basic mock garth module with successful operations."""
-    from unittest.mock import MagicMock, Mock
+def mock_garmin_client():
+    """Mock garminconnect.Garmin for upload tests."""
+    from unittest.mock import MagicMock, patch
 
-    mock_garth = MagicMock()
-    mock_garth_exc = MagicMock()
-
-    mock_garth_exc.GarthException = MockGarthException
-    mock_garth_exc.GarthHTTPError = MockGarthHTTPError
-
-    mock_garth.resume.return_value = None
-    mock_garth.client.username = "test_user"
-    mock_garth.client.upload = Mock()
-
-    return mock_garth, mock_garth_exc
-
-
-@pytest.fixture
-def mock_garth_with_login(mock_garth_basic):
-    """Create mock garth that requires login."""
-    mock_garth, mock_garth_exc = mock_garth_basic
-
-    mock_garth.resume.side_effect = MockGarthException("Session expired")
-    mock_garth.login.return_value = None
-    mock_garth.save.return_value = None
-
-    return mock_garth, mock_garth_exc
+    with patch("fit_file_faker.app.Garmin") as mock_cls:
+        mock_instance = MagicMock()
+        mock_cls.return_value = mock_instance
+        mock_instance.login.return_value = (None, None)
+        mock_instance.upload_activity.return_value = {
+            "detailedImportResult": {"successes": [{}]}
+        }
+        yield mock_cls, mock_instance
 
 
 # ==============================================================================

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -19,9 +19,6 @@ from fit_file_faker.app import (
     upload_all,
 )
 
-# Import shared mock classes from conftest
-from .conftest import MockGarthHTTPError
-
 
 # Test Fixtures and Helpers
 
@@ -43,109 +40,99 @@ def mock_valid_config():
 class TestUploadFunction:
     """Tests for the upload functionality with mocked Garmin requests."""
 
-    def test_upload_success(self, tpv_fit_file, mock_garth_basic, mock_valid_config):
+    def test_upload_success(self, tpv_fit_file, mock_garmin_client, mock_valid_config):
         """Test successful file upload to Garmin Connect."""
-        mock_garth, mock_garth_exc = mock_garth_basic
+        mock_cls, mock_instance = mock_garmin_client
         mock_profile = mock_valid_config.config.get_default_profile()
 
-        with patch.dict(
-            "sys.modules", {"garth": mock_garth, "garth.exc": mock_garth_exc}
-        ):
-            upload(tpv_fit_file, profile=mock_profile, dryrun=False)
-            mock_garth.client.upload.assert_called_once()
+        upload(tpv_fit_file, profile=mock_profile, dryrun=False)
 
-    def test_upload_with_login(
-        self, tpv_fit_file, mock_garth_with_login, mock_valid_config
+        mock_instance.login.assert_called_once()
+        mock_instance.upload_activity.assert_called_once()
+
+    def test_upload_requires_login(
+        self, tpv_fit_file, mock_garmin_client, mock_valid_config
     ):
-        """Test upload that requires login."""
-        mock_garth, mock_garth_exc = mock_garth_with_login
+        """Test that login is always called before upload."""
+        mock_cls, mock_instance = mock_garmin_client
         mock_profile = mock_valid_config.config.get_default_profile()
 
-        with patch.dict(
-            "sys.modules", {"garth": mock_garth, "garth.exc": mock_garth_exc}
-        ):
-            upload(tpv_fit_file, profile=mock_profile, dryrun=False)
+        upload(tpv_fit_file, profile=mock_profile, dryrun=False)
 
-            # Verify login was called with config credentials
-            mock_garth.login.assert_called_once_with("test@example.com", "testpass")
-            mock_garth.save.assert_called_once()
+        mock_instance.login.assert_called_once()
 
-    def test_upload_http_errors(
-        self, tpv_fit_file, mock_garth_basic, caplog, mock_valid_config
+    def test_upload_conflict_409(
+        self, tpv_fit_file, mock_garmin_client, caplog, mock_valid_config
     ):
-        """Test upload handling HTTP errors - 409 conflict handled gracefully, others raise."""
-        mock_garth, mock_garth_exc = mock_garth_basic
+        """Test upload handles 409 conflict (duplicate activity) gracefully."""
+        from garminconnect import GarminConnectConnectionError
+
+        mock_cls, mock_instance = mock_garmin_client
         mock_profile = mock_valid_config.config.get_default_profile()
 
-        # Test 409 conflict (duplicate activity) - should be handled gracefully
-        mock_garth.client.upload = Mock(side_effect=MockGarthHTTPError(409))
-        with patch.dict(
-            "sys.modules", {"garth": mock_garth, "garth.exc": mock_garth_exc}
-        ):
+        mock_instance.upload_activity.side_effect = GarminConnectConnectionError(
+            "API Error 409 - Conflict"
+        )
+
+        upload(
+            tpv_fit_file,
+            profile=mock_profile,
+            original_path=Path("test.fit"),
+            dryrun=False,
+        )
+
+        assert "conflict" in caplog.text.lower() or "409" in caplog.text
+
+    def test_upload_http_error(
+        self, tpv_fit_file, mock_garmin_client, mock_valid_config
+    ):
+        """Test upload re-raises non-409 HTTP errors."""
+        from garminconnect import GarminConnectConnectionError
+
+        mock_cls, mock_instance = mock_garmin_client
+        mock_profile = mock_valid_config.config.get_default_profile()
+
+        mock_instance.upload_activity.side_effect = GarminConnectConnectionError(
+            "API Error 500 - Server Error"
+        )
+
+        with pytest.raises(GarminConnectConnectionError):
             upload(
                 tpv_fit_file,
                 profile=mock_profile,
                 original_path=Path("test.fit"),
                 dryrun=False,
             )
-            assert "conflict" in caplog.text.lower() or "409" in caplog.text
 
-        # Test non-409 errors (500) - should raise exception
-        caplog.clear()
-        mock_garth.client.upload = Mock(side_effect=MockGarthHTTPError(500))
-        with patch.dict(
-            "sys.modules", {"garth": mock_garth, "garth.exc": mock_garth_exc}
-        ):
-            with pytest.raises(MockGarthHTTPError):
-                upload(
-                    tpv_fit_file,
-                    profile=mock_profile,
-                    original_path=Path("test.fit"),
-                    dryrun=False,
-                )
-
-    def test_upload_dryrun(self, tpv_fit_file, mock_garth_basic, mock_valid_config):
+    def test_upload_dryrun(self, tpv_fit_file, mock_garmin_client, mock_valid_config):
         """Test that dryrun doesn't actually upload."""
-        mock_garth, mock_garth_exc = mock_garth_basic
+        mock_cls, mock_instance = mock_garmin_client
         mock_profile = mock_valid_config.config.get_default_profile()
 
-        with patch.dict(
-            "sys.modules", {"garth": mock_garth, "garth.exc": mock_garth_exc}
-        ):
-            upload(tpv_fit_file, profile=mock_profile, dryrun=True)
-            mock_garth.client.upload.assert_not_called()
+        upload(tpv_fit_file, profile=mock_profile, dryrun=True)
 
-    def test_upload_interactive_credentials(self, tpv_fit_file, mock_garth_with_login):
-        """Test interactive credential input when not in config."""
-        mock_garth, mock_garth_exc = mock_garth_with_login
+        mock_instance.login.assert_called_once()
+        mock_instance.upload_activity.assert_not_called()
 
-        with (
-            patch.dict(
-                "sys.modules", {"garth": mock_garth, "garth.exc": mock_garth_exc}
-            ),
-            patch("fit_file_faker.app.questionary") as mock_questionary,
-            patch("fit_file_faker.app.config_manager") as mock_config_manager,
-        ):
-            # Mock questionary to provide credentials
-            mock_questionary.text.return_value.ask.return_value = (
-                "interactive@example.com"
-            )
-            mock_questionary.password.return_value.ask.return_value = "interactive_pass"
+    def test_upload_missing_credentials(self, tpv_fit_file, mock_garmin_client):
+        """Test that ValueError is raised when profile has no credentials."""
+        mock_profile = MagicMock()
+        mock_profile.name = "test"
+        mock_profile.garmin_username = None
+        mock_profile.garmin_password = None
 
-            # Mock profile with no credentials
-            mock_profile = MagicMock()
-            mock_profile.garmin_username = None
-            mock_profile.garmin_password = None
-            mock_config_manager.config.get_default_profile.return_value = mock_profile
-
+        with pytest.raises(ValueError, match="missing Garmin credentials"):
             upload(tpv_fit_file, profile=mock_profile, dryrun=False)
 
-            # Verify interactive prompts were used
-            mock_questionary.text.assert_called_once()
-            mock_questionary.password.assert_called_once()
-            mock_garth.login.assert_called_once_with(
-                "interactive@example.com", "interactive_pass"
-            )
+    def test_upload_missing_password(self, tpv_fit_file, mock_garmin_client):
+        """Test that ValueError is raised when profile has no password."""
+        mock_profile = MagicMock()
+        mock_profile.name = "test"
+        mock_profile.garmin_username = "user@example.com"
+        mock_profile.garmin_password = None
+
+        with pytest.raises(ValueError, match="missing Garmin credentials"):
+            upload(tpv_fit_file, profile=mock_profile, dryrun=False)
 
 
 class TestUploadAllFunction:
@@ -1370,18 +1357,18 @@ class TestCLIIntegration:
                 "Test error message" in record.message for record in caplog.records
             )
 
-    def test_show_dirs_flag_with_garth_dirs(self, capsys):
-        """Test --show-dirs flag when garth directories exist."""
+    def test_show_dirs_flag_with_garmin_dirs(self, capsys):
+        """Test --show-dirs flag when garmin token directories exist."""
         import re
         from fit_file_faker.app import run
         from fit_file_faker.config import dirs
 
-        # Create actual garth directories in the cache path
+        # Create actual garmin token directories in the data path
         # (isolate_config_dirs fixture ensures this is a tmp directory)
-        garth_dir1 = dirs.user_cache_path / ".garth_profile1"
-        garth_dir2 = dirs.user_cache_path / ".garth_profile2"
-        garth_dir1.mkdir(parents=True, exist_ok=True)
-        garth_dir2.mkdir(parents=True, exist_ok=True)
+        garmin_dir1 = dirs.user_data_path / ".garmin_profile1"
+        garmin_dir2 = dirs.user_data_path / ".garmin_profile2"
+        garmin_dir1.mkdir(parents=True, exist_ok=True)
+        garmin_dir2.mkdir(parents=True, exist_ok=True)
 
         with patch("sys.argv", ["fit-file-faker", "--show-dirs"]):
             with pytest.raises(SystemExit) as exc_info:
@@ -1397,6 +1384,7 @@ class TestCLIIntegration:
         output_normalized = re.sub(r"\s+", "", captured.out)
         config_path_normalized = re.sub(r"\s+", "", str(dirs.user_config_path))
         cache_path_normalized = re.sub(r"\s+", "", str(dirs.user_cache_path))
+        data_path_normalized = re.sub(r"\s+", "", str(dirs.user_data_path))
 
         # Verify that the output contains the expected sections
         assert "Executable:" in captured.out
@@ -1405,20 +1393,22 @@ class TestCLIIntegration:
         assert config_path_normalized in output_normalized
         assert "Cache directory:" in captured.out
         assert cache_path_normalized in output_normalized
+        assert "Data directory:" in captured.out
+        assert data_path_normalized in output_normalized
 
-        # Should show that garth directories were found
-        assert "Garmin credential directories:" in captured.out
-        assert ".garth_profile1" in captured.out
-        assert ".garth_profile2" in captured.out
+        # Should show that garmin token directories were found
+        assert "Garmin token directories:" in captured.out
+        assert ".garmin_profile1" in captured.out
+        assert ".garmin_profile2" in captured.out
 
-    def test_show_dirs_flag_without_garth_dirs(self, capsys):
-        """Test --show-dirs flag when no garth directories exist."""
+    def test_show_dirs_flag_without_garmin_dirs(self, capsys):
+        """Test --show-dirs flag when no garmin token directories exist."""
         import re
         from fit_file_faker.app import run
         from fit_file_faker.config import dirs
 
-        # Don't create any garth directories
-        # (isolate_config_dirs fixture ensures cache directory is empty)
+        # Don't create any garmin directories
+        # (isolate_config_dirs fixture ensures data directory is empty)
 
         with patch("sys.argv", ["fit-file-faker", "--show-dirs"]):
             with pytest.raises(SystemExit) as exc_info:
@@ -1443,6 +1433,6 @@ class TestCLIIntegration:
         assert "Cache directory:" in captured.out
         assert cache_path_normalized in output_normalized
 
-        # Should show message about no garth directories found
-        assert "No Garmin credential directories found" in captured.out
+        # Should show message about no garmin token directories found
+        assert "No Garmin token directories found" in captured.out
         assert "will be created on first use" in captured.out

--- a/tests/test_integration_profiles.py
+++ b/tests/test_integration_profiles.py
@@ -12,7 +12,7 @@ from unittest.mock import patch
 
 import pytest
 
-from fit_file_faker.app import get_garth_dir, upload, upload_all
+from fit_file_faker.app import get_token_dir, upload, upload_all
 from fit_file_faker.config import AppType, ConfigManager, Profile, ProfileManager
 
 
@@ -57,10 +57,10 @@ class TestMultiProfileWorkflows:
         assert config_manager.config.default_profile == "tpv"
         assert config_manager.config.get_default_profile() == tpv_profile
 
-    def test_profile_specific_garth_isolation(self):
-        """Test that each profile gets its own isolated garth directory."""
-        profile1_dir = get_garth_dir("profile1")
-        profile2_dir = get_garth_dir("profile2")
+    def test_profile_specific_token_isolation(self):
+        """Test that each profile gets its own isolated token directory."""
+        profile1_dir = get_token_dir("profile1")
+        profile2_dir = get_token_dir("profile2")
 
         # Verify directories are different
         assert profile1_dir != profile2_dir
@@ -72,15 +72,15 @@ class TestMultiProfileWorkflows:
         assert profile2_dir.exists()
 
         # Test with special characters in profile name (should be sanitized)
-        special_profile_dir = get_garth_dir("my profile!")
+        special_profile_dir = get_token_dir("my profile!")
         assert special_profile_dir.exists()
         assert "my_profile_" in str(special_profile_dir)
 
     def test_upload_with_different_profiles(
-        self, tmp_path, tpv_fit_file, mock_garth_basic
+        self, tmp_path, tpv_fit_file, mock_garmin_client
     ):
         """Test uploading the same file with different profiles."""
-        mock_garth, mock_garth_exc = mock_garth_basic
+        mock_cls, mock_instance = mock_garmin_client
 
         # Create two profiles
         profile1 = Profile(
@@ -98,17 +98,13 @@ class TestMultiProfileWorkflows:
             fitfiles_path=tmp_path,
         )
 
-        # Mock garth module for upload function
-        with patch.dict(
-            "sys.modules", {"garth": mock_garth, "garth.exc": mock_garth_exc}
-        ):
-            # Upload with profile 1
-            upload(tpv_fit_file, profile=profile1, dryrun=False)
-            # Upload with profile 2
-            upload(tpv_fit_file, profile=profile2, dryrun=False)
+        # Upload with profile 1
+        upload(tpv_fit_file, profile=profile1, dryrun=False)
+        # Upload with profile 2
+        upload(tpv_fit_file, profile=profile2, dryrun=False)
 
-            # Verify upload was called twice
-            assert mock_garth.client.upload.call_count == 2
+        # Verify upload_activity was called twice
+        assert mock_instance.upload_activity.call_count == 2
 
     def test_migration_workflow(self, tmp_path):
         """Test complete migration workflow from legacy to multi-profile."""

--- a/uv.lock
+++ b/uv.lock
@@ -3,15 +3,6 @@ revision = 3
 requires-python = ">=3.12.0"
 
 [[package]]
-name = "annotated-types"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
-]
-
-[[package]]
 name = "babel"
 version = "2.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -47,6 +38,63 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", size = 154268, upload-time = "2026-01-04T02:42:41.825Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", size = 152900, upload-time = "2026-01-04T02:42:40.15Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
 ]
 
 [[package]]
@@ -217,6 +265,39 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/2a/8c3ac3d8bc94e6de8d7ae270bb5bc437b210bb9d6d9e46630c98f4abd20c/csscompressor-0.9.5.tar.gz", hash = "sha256:afa22badbcf3120a4f392e4d22f9fff485c044a1feda4a950ecc5eba9dd31a05", size = 237808, upload-time = "2017-11-26T21:13:08.238Z" }
 
 [[package]]
+name = "curl-cffi"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "cffi" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/5b/89fcfebd3e5e85134147ac99e9f2b2271165fd4d71984fc65da5f17819b7/curl_cffi-0.15.0.tar.gz", hash = "sha256:ea0c67652bf6893d34ee0f82c944f37e488f6147e9421bef1771cc6545b02ded", size = 196437, upload-time = "2026-04-03T11:12:31.525Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/42/54ddd442c795f30ce5dd4e49f87ce77505958d3777cd96a91567a3975d2a/curl_cffi-0.15.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:bda66404010e9ed743b1b83c20c86f24fe21a9a6873e17479d6e67e29d8ded28", size = 2795267, upload-time = "2026-04-03T11:11:46.48Z" },
+    { url = "https://files.pythonhosted.org/packages/83/2d/3915e238579b3c5a92cead5c79130c3b8d20caaba7616cc4d894650e1d6b/curl_cffi-0.15.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:a25620d9bf989c9c029a7d1642999c4c265abb0bad811deb2f77b0b5b2b12e5b", size = 2573544, upload-time = "2026-04-03T11:11:47.951Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/b3/9d2f1057749a1b07ba1989db3c1503ce8bed998310bae9aea2c43aa64f20/curl_cffi-0.15.0-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:582e570aa2586b96ed47cf4a17586b9a3c462cbe43f780487c3dc245c6ef1527", size = 10515369, upload-time = "2026-04-03T11:11:50.126Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/1d/6d10dded5ce3fd8157e558ebd97d09e551b77a62cdc1c31e93d0a633cee5/curl_cffi-0.15.0-cp310-abi3-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:838e48212447d9c81364b04707a5c861daf08f8320f9ecb3406a8919d1d5c3b3", size = 10160045, upload-time = "2026-04-03T11:11:52.664Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/12/c70b835487ace3b9ba1502631912e3440082b8ae3a162f60b59cb0b6444d/curl_cffi-0.15.0-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b6c847d86283b07ae69bb72c82eb8a59242277142aa35b89850f89e792a02fc", size = 11090433, upload-time = "2026-04-03T11:11:55.049Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/0d/78edcc4f71934225db99df68197a107386d59080742fc7bf6bb4d007924f/curl_cffi-0.15.0-cp310-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:9e5e69eee735f659287e2c84444319d68a1fa68dd37abf228943a4074864283a", size = 10479178, upload-time = "2026-04-03T11:11:57.685Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/84/1e101c1acb1ea2f0b4992f5c3024f596d8e21db0d53540b9d583f673c4e7/curl_cffi-0.15.0-cp310-abi3-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aa1323950224db24f4c510d010b3affa02196ca853fb424191fa917a513d3f4b", size = 10317051, upload-time = "2026-04-03T11:12:00.295Z" },
+    { url = "https://files.pythonhosted.org/packages/28/42/8ef236b22a6c23d096c85a1dc507efe37bfdfc7a2f8a4b34efb590197369/curl_cffi-0.15.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:41f80170ba844009273b2660da1964ec31e99e5719d16b3422ada87177e32e13", size = 11299660, upload-time = "2026-04-03T11:12:02.791Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/01/56aeb055d962da87a1be0d74c6c644e251c7e88129b5471dc44ac724e678/curl_cffi-0.15.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1977e1e12cfb5c11352cbb74acef1bed24eb7d226dab61ca57c168c21acd4d61", size = 11945049, upload-time = "2026-04-03T11:12:05.912Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/8c/2abf99a38d6340d66cf0557e0c750ef3f8883dfc5d450087e01c85861343/curl_cffi-0.15.0-cp310-abi3-win_amd64.whl", hash = "sha256:5a0c1896a0d5a5ac1eb89cd24b008d2b718dd1df6fd2f75451b59ca66e49e572", size = 1661649, upload-time = "2026-04-03T11:12:07.948Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/39/dfd54f2240d3a9b96d77bacc62b97813b35e2aa8ecf5cd5013c683f1ba96/curl_cffi-0.15.0-cp310-abi3-win_arm64.whl", hash = "sha256:a6d57f8389273a3a1f94370473c74897467bcc36af0a17336989780c507fa43d", size = 1410741, upload-time = "2026-04-03T11:12:10.073Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6a/c24df8a4fc22fa84070dcd94abeba43c15e08cc09e35869565c0bad196fd/curl_cffi-0.15.0-cp313-abi3-android_24_arm64_v8a.whl", hash = "sha256:4682dc38d4336e0eb0b185374db90a760efde63cbea994b4e63f3521d44c4c92", size = 7190427, upload-time = "2026-04-03T11:12:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/11/56/132225cb3491d07cc6adcce5fe395e059bde87c68cff1ef87a31c88c7819/curl_cffi-0.15.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:967ad7355bd8e9586f8c2d02eaa99953747549e7ea4a9b25cd53353e6b67fe6d", size = 2795723, upload-time = "2026-04-03T11:12:13.668Z" },
+    { url = "https://files.pythonhosted.org/packages/07/8f/f4f83cd303bef7e8f1749512e5dd157e7e5d08b0a36c8211f9640a2757bf/curl_cffi-0.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7e63539d0d839d0a8c5eacf86229bc68c57803547f35e0db7ee0986328b478c3", size = 2573739, upload-time = "2026-04-03T11:12:15.08Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/5c/643d65c7fc9acd742876aa55c2d7823c438cb7665810acd2e66c9976c4d9/curl_cffi-0.15.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:08c799b89740b9bc49c09fbc3d5907f13ac1f845ca52620507ef9466d4639dd5", size = 10521046, upload-time = "2026-04-03T11:12:17.034Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/0b/9b8037113c93f4c5323096163471fa7c35c7676c3f608eeaf1287cd99d58/curl_cffi-0.15.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b7a92767a888ee90147e18964b396d8435ff42737030d6fb00824ffd6094805", size = 11096115, upload-time = "2026-04-03T11:12:19.694Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/96/fff2fcbd924ef4042e0d67379f751a8a4e3186a91e75e35a4cf218b306ee/curl_cffi-0.15.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:829cc357061ecb99cc2d406301f609a039e05665322f5c025ec67c38b0dc49ce", size = 11305346, upload-time = "2026-04-03T11:12:22.151Z" },
+    { url = "https://files.pythonhosted.org/packages/53/1b/304b253a45ab28691c8c5e8cca1e6cbb9cf8e46dfceae4648dd536f75e73/curl_cffi-0.15.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:408d6f14e346841cd889c2e0962832bb235ba3b6749ebf609f347f747da5e60f", size = 11949834, upload-time = "2026-04-03T11:12:24.986Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ff/4723d92f08259c707a974aba27a08d0a822b9555e35ca581bf18d055a364/curl_cffi-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b624c7ce087bfda967a013ed0a64702a525444e5b6e97d23534d567ccc6525aa", size = 1702771, upload-time = "2026-04-03T11:12:28.201Z" },
+    { url = "https://files.pythonhosted.org/packages/59/8c/36bbe06d66fa2b765e4a07199f643a59a9cd1a754207a96335402a9520f4/curl_cffi-0.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0b6c0543b993996670e9e4b78e305a2d60809d5681903ffb5568e21a387434d3", size = 1466312, upload-time = "2026-04-03T11:12:30.054Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -258,7 +339,7 @@ version = "2.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "bitstruct" },
-    { name = "garth" },
+    { name = "garminconnect" },
     { name = "openpyxl" },
     { name = "platformdirs" },
     { name = "questionary" },
@@ -290,7 +371,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "bitstruct", specifier = "==8.11.1" },
-    { name = "garth", specifier = ">=0.5.21" },
+    { name = "garminconnect", specifier = ">=0.3.3" },
     { name = "openpyxl", specifier = "==2.5.12" },
     { name = "platformdirs", specifier = ">=4.5.1" },
     { name = "questionary", specifier = ">=2.1.1" },
@@ -320,17 +401,17 @@ docs = [
 ]
 
 [[package]]
-name = "garth"
-version = "0.5.21"
+name = "garminconnect"
+version = "0.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic" },
+    { name = "curl-cffi" },
     { name = "requests" },
-    { name = "requests-oauthlib" },
+    { name = "ua-generator" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/14/1a/e559feb5efd53e9a5d15c28007a714e240a51363c79a306727977fe1999b/garth-0.5.21.tar.gz", hash = "sha256:8d979595d1d4ea23a1b466ab4a60955d139b71f886f46490be140fcee584dab4", size = 1840358, upload-time = "2026-01-07T23:12:33.828Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/d9/7ad240d86453de083f0c460ee328e8209232d9d0ee099dcf49439d90be7a/garminconnect-0.3.3.tar.gz", hash = "sha256:f608193d7a90079fa1fd1d86e8d10e88b871b6ab2500372a9dc48358f8c2d386", size = 52234, upload-time = "2026-04-22T12:57:24.79Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/14/b7c77f363ff04cc0c57991277b8c3564df5210b0879894e2033f90f55ff5/garth-0.5.21-py3-none-any.whl", hash = "sha256:24b8c517ef24ef030bca14cf4e8d7ad7a191d9bc60ece6077fec6ea743a5d039", size = 33265, upload-time = "2026-01-07T23:12:32.069Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/5a/69af564ff61c87a725e0a6b6ceed4a01569a1caced2c136042c778907244/garminconnect-0.3.3-py3-none-any.whl", hash = "sha256:e11dbbddf20abd60d5c8fbde1e7c688ca175a905237dfec8837ee935a1aca803", size = 47814, upload-time = "2026-04-22T12:57:23.175Z" },
 ]
 
 [[package]]
@@ -677,15 +758,6 @@ wheels = [
 ]
 
 [[package]]
-name = "oauthlib"
-version = "3.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
-]
-
-[[package]]
 name = "openpyxl"
 version = "2.5.12"
 source = { registry = "https://pypi.org/simple" }
@@ -769,89 +841,12 @@ wheels = [
 ]
 
 [[package]]
-name = "pydantic"
-version = "2.12.5"
+name = "pycparser"
+version = "3.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "annotated-types" },
-    { name = "pydantic-core" },
-    { name = "typing-extensions" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
-]
-
-[[package]]
-name = "pydantic-core"
-version = "2.41.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/5d/5f6c63eebb5afee93bcaae4ce9a898f3373ca23df3ccaef086d0233a35a7/pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7", size = 2110990, upload-time = "2025-11-04T13:39:58.079Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/32/9c2e8ccb57c01111e0fd091f236c7b371c1bccea0fa85247ac55b1e2b6b6/pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0", size = 1896003, upload-time = "2025-11-04T13:39:59.956Z" },
-    { url = "https://files.pythonhosted.org/packages/68/b8/a01b53cb0e59139fbc9e4fda3e9724ede8de279097179be4ff31f1abb65a/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69", size = 1919200, upload-time = "2025-11-04T13:40:02.241Z" },
-    { url = "https://files.pythonhosted.org/packages/38/de/8c36b5198a29bdaade07b5985e80a233a5ac27137846f3bc2d3b40a47360/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75", size = 2052578, upload-time = "2025-11-04T13:40:04.401Z" },
-    { url = "https://files.pythonhosted.org/packages/00/b5/0e8e4b5b081eac6cb3dbb7e60a65907549a1ce035a724368c330112adfdd/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05", size = 2208504, upload-time = "2025-11-04T13:40:06.072Z" },
-    { url = "https://files.pythonhosted.org/packages/77/56/87a61aad59c7c5b9dc8caad5a41a5545cba3810c3e828708b3d7404f6cef/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc", size = 2335816, upload-time = "2025-11-04T13:40:07.835Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c", size = 2075366, upload-time = "2025-11-04T13:40:09.804Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/43/ebef01f69baa07a482844faaa0a591bad1ef129253ffd0cdaa9d8a7f72d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5", size = 2171698, upload-time = "2025-11-04T13:40:12.004Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/87/41f3202e4193e3bacfc2c065fab7706ebe81af46a83d3e27605029c1f5a6/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c", size = 2132603, upload-time = "2025-11-04T13:40:13.868Z" },
-    { url = "https://files.pythonhosted.org/packages/49/7d/4c00df99cb12070b6bccdef4a195255e6020a550d572768d92cc54dba91a/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294", size = 2329591, upload-time = "2025-11-04T13:40:15.672Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/6a/ebf4b1d65d458f3cda6a7335d141305dfa19bdc61140a884d165a8a1bbc7/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1", size = 2319068, upload-time = "2025-11-04T13:40:17.532Z" },
-    { url = "https://files.pythonhosted.org/packages/49/3b/774f2b5cd4192d5ab75870ce4381fd89cf218af999515baf07e7206753f0/pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d", size = 1985908, upload-time = "2025-11-04T13:40:19.309Z" },
-    { url = "https://files.pythonhosted.org/packages/86/45/00173a033c801cacf67c190fef088789394feaf88a98a7035b0e40d53dc9/pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815", size = 2020145, upload-time = "2025-11-04T13:40:21.548Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/22/91fbc821fa6d261b376a3f73809f907cec5ca6025642c463d3488aad22fb/pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3", size = 1976179, upload-time = "2025-11-04T13:40:23.393Z" },
-    { url = "https://files.pythonhosted.org/packages/87/06/8806241ff1f70d9939f9af039c6c35f2360cf16e93c2ca76f184e76b1564/pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9", size = 2120403, upload-time = "2025-11-04T13:40:25.248Z" },
-    { url = "https://files.pythonhosted.org/packages/94/02/abfa0e0bda67faa65fef1c84971c7e45928e108fe24333c81f3bfe35d5f5/pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34", size = 1896206, upload-time = "2025-11-04T13:40:27.099Z" },
-    { url = "https://files.pythonhosted.org/packages/15/df/a4c740c0943e93e6500f9eb23f4ca7ec9bf71b19e608ae5b579678c8d02f/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0", size = 1919307, upload-time = "2025-11-04T13:40:29.806Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/e3/6324802931ae1d123528988e0e86587c2072ac2e5394b4bc2bc34b61ff6e/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33", size = 2063258, upload-time = "2025-11-04T13:40:33.544Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/d4/2230d7151d4957dd79c3044ea26346c148c98fbf0ee6ebd41056f2d62ab5/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e", size = 2214917, upload-time = "2025-11-04T13:40:35.479Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/9f/eaac5df17a3672fef0081b6c1bb0b82b33ee89aa5cec0d7b05f52fd4a1fa/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2", size = 2332186, upload-time = "2025-11-04T13:40:37.436Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/4e/35a80cae583a37cf15604b44240e45c05e04e86f9cfd766623149297e971/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586", size = 2073164, upload-time = "2025-11-04T13:40:40.289Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/e3/f6e262673c6140dd3305d144d032f7bd5f7497d3871c1428521f19f9efa2/pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d", size = 2179146, upload-time = "2025-11-04T13:40:42.809Z" },
-    { url = "https://files.pythonhosted.org/packages/75/c7/20bd7fc05f0c6ea2056a4565c6f36f8968c0924f19b7d97bbfea55780e73/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740", size = 2137788, upload-time = "2025-11-04T13:40:44.752Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/8d/34318ef985c45196e004bc46c6eab2eda437e744c124ef0dbe1ff2c9d06b/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e", size = 2340133, upload-time = "2025-11-04T13:40:46.66Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/59/013626bf8c78a5a5d9350d12e7697d3d4de951a75565496abd40ccd46bee/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858", size = 2324852, upload-time = "2025-11-04T13:40:48.575Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36", size = 1994679, upload-time = "2025-11-04T13:40:50.619Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11", size = 2019766, upload-time = "2025-11-04T13:40:52.631Z" },
-    { url = "https://files.pythonhosted.org/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd", size = 1981005, upload-time = "2025-11-04T13:40:54.734Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/28/46b7c5c9635ae96ea0fbb779e271a38129df2550f763937659ee6c5dbc65/pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a", size = 2119622, upload-time = "2025-11-04T13:40:56.68Z" },
-    { url = "https://files.pythonhosted.org/packages/74/1a/145646e5687e8d9a1e8d09acb278c8535ebe9e972e1f162ed338a622f193/pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14", size = 1891725, upload-time = "2025-11-04T13:40:58.807Z" },
-    { url = "https://files.pythonhosted.org/packages/23/04/e89c29e267b8060b40dca97bfc64a19b2a3cf99018167ea1677d96368273/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1", size = 1915040, upload-time = "2025-11-04T13:41:00.853Z" },
-    { url = "https://files.pythonhosted.org/packages/84/a3/15a82ac7bd97992a82257f777b3583d3e84bdb06ba6858f745daa2ec8a85/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66", size = 2063691, upload-time = "2025-11-04T13:41:03.504Z" },
-    { url = "https://files.pythonhosted.org/packages/74/9b/0046701313c6ef08c0c1cf0e028c67c770a4e1275ca73131563c5f2a310a/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869", size = 2213897, upload-time = "2025-11-04T13:41:05.804Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/cd/6bac76ecd1b27e75a95ca3a9a559c643b3afcd2dd62086d4b7a32a18b169/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2", size = 2333302, upload-time = "2025-11-04T13:41:07.809Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375", size = 2064877, upload-time = "2025-11-04T13:41:09.827Z" },
-    { url = "https://files.pythonhosted.org/packages/18/66/e9db17a9a763d72f03de903883c057b2592c09509ccfe468187f2a2eef29/pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553", size = 2180680, upload-time = "2025-11-04T13:41:12.379Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/9e/3ce66cebb929f3ced22be85d4c2399b8e85b622db77dad36b73c5387f8f8/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90", size = 2138960, upload-time = "2025-11-04T13:41:14.627Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/62/205a998f4327d2079326b01abee48e502ea739d174f0a89295c481a2272e/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07", size = 2339102, upload-time = "2025-11-04T13:41:16.868Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/0d/f05e79471e889d74d3d88f5bd20d0ed189ad94c2423d81ff8d0000aab4ff/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb", size = 2326039, upload-time = "2025-11-04T13:41:18.934Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/e1/e08a6208bb100da7e0c4b288eed624a703f4d129bde2da475721a80cab32/pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23", size = 1995126, upload-time = "2025-11-04T13:41:21.418Z" },
-    { url = "https://files.pythonhosted.org/packages/48/5d/56ba7b24e9557f99c9237e29f5c09913c81eeb2f3217e40e922353668092/pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf", size = 2015489, upload-time = "2025-11-04T13:41:24.076Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/bb/f7a190991ec9e3e0ba22e4993d8755bbc4a32925c0b5b42775c03e8148f9/pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0", size = 1977288, upload-time = "2025-11-04T13:41:26.33Z" },
-    { url = "https://files.pythonhosted.org/packages/92/ed/77542d0c51538e32e15afe7899d79efce4b81eee631d99850edc2f5e9349/pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a", size = 2120255, upload-time = "2025-11-04T13:41:28.569Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/3d/6913dde84d5be21e284439676168b28d8bbba5600d838b9dca99de0fad71/pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3", size = 1863760, upload-time = "2025-11-04T13:41:31.055Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/f0/e5e6b99d4191da102f2b0eb9687aaa7f5bea5d9964071a84effc3e40f997/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c", size = 1878092, upload-time = "2025-11-04T13:41:33.21Z" },
-    { url = "https://files.pythonhosted.org/packages/71/48/36fb760642d568925953bcc8116455513d6e34c4beaa37544118c36aba6d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612", size = 2053385, upload-time = "2025-11-04T13:41:35.508Z" },
-    { url = "https://files.pythonhosted.org/packages/20/25/92dc684dd8eb75a234bc1c764b4210cf2646479d54b47bf46061657292a8/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d", size = 2218832, upload-time = "2025-11-04T13:41:37.732Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/09/f53e0b05023d3e30357d82eb35835d0f6340ca344720a4599cd663dca599/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9", size = 2327585, upload-time = "2025-11-04T13:41:40Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/4e/2ae1aa85d6af35a39b236b1b1641de73f5a6ac4d5a7509f77b814885760c/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660", size = 2041078, upload-time = "2025-11-04T13:41:42.323Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/13/2e215f17f0ef326fc72afe94776edb77525142c693767fc347ed6288728d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9", size = 2173914, upload-time = "2025-11-04T13:41:45.221Z" },
-    { url = "https://files.pythonhosted.org/packages/02/7a/f999a6dcbcd0e5660bc348a3991c8915ce6599f4f2c6ac22f01d7a10816c/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3", size = 2129560, upload-time = "2025-11-04T13:41:47.474Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/b1/6c990ac65e3b4c079a4fb9f5b05f5b013afa0f4ed6780a3dd236d2cbdc64/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf", size = 2329244, upload-time = "2025-11-04T13:41:49.992Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/02/3c562f3a51afd4d88fff8dffb1771b30cfdfd79befd9883ee094f5b6c0d8/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470", size = 2331955, upload-time = "2025-11-04T13:41:54.079Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
-    { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
-    { url = "https://files.pythonhosted.org/packages/09/32/59b0c7e63e277fa7911c2fc70ccfb45ce4b98991e7ef37110663437005af/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd", size = 2110495, upload-time = "2025-11-04T13:42:49.689Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]
@@ -1029,19 +1024,6 @@ wheels = [
 ]
 
 [[package]]
-name = "requests-oauthlib"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "oauthlib" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
-]
-
-[[package]]
 name = "rich"
 version = "14.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1118,24 +1100,12 @@ wheels = [
 ]
 
 [[package]]
-name = "typing-extensions"
-version = "4.15.0"
+name = "ua-generator"
+version = "2.0.26"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/96/926e0a7bfc39c6474020cc333c58260a46cbfba8f7a5e5c879069f3647e8/ua_generator-2.0.26.tar.gz", hash = "sha256:91e939d80529cfe1bb71e711bad9397b3bdead5440fe9c0445cf07e08fb19d2e", size = 28431, upload-time = "2026-04-26T11:06:20.067Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
-]
-
-[[package]]
-name = "typing-inspection"
-version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d2/7e9510177b3516f607fbcd0624d934b5fa81d0de8a9938c2f922c4bf6207/ua_generator-2.0.26-py3-none-any.whl", hash = "sha256:922283a6e950b74df641ab2f31d29d5470e0dfd4659e2474dbee94cd4ab50689", size = 32517, upload-time = "2026-04-26T11:06:18.518Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Background

Garmin changed their authentication flow to use Cloudflare TLS fingerprinting, which blocks `garth`'s mobile user-agent (`GCM-iOS-5.7.2.1`). This prevents OAuth tokens from being created, breaking all uploads. Also, as of now, the `garth` project is effectively archived and so we should no longer rely on it.

This PR swaps out garth with `python-garminconnect` for authentication and uploading files.

Closes #75.

## Changes

- **Dependency swap**: `garth>=0.5.21` → `garminconnect>=0.3.3`
- **`get_garth_dir()` → `get_token_dir()`**: Token storage moved from `user_cache_path` to `user_data_path` so tokens survive routine cache wipes; directory prefix changes from `.garth_<name>` to `.garmin_<name>`
- **`upload()` rewritten**: Uses `Garmin(email, password).login(tokenstore=...)` + `upload_activity()`; raises `ValueError` immediately for missing credentials instead of prompting interactively
- **`--show-dirs`**: Now shows the data directory and lists `.garmin_*` token directories
- **Logging**: Removed `oauth1_auth` logger suppression (garth-specific)
- **Tests**: Replaced `mock_garth_*` fixtures with `mock_garmin_client`; updated show-dirs tests for new directory names and locations

## Upgrade behavior for users

- Re-authentication happens automatically on first run after upgrade (no manual steps required)
- Existing `.garth_*` directories are left behind as orphaned dirs; they cause no harm but can be manually deleted
- `garminconnect` automatically falls back through multiple login strategies if rate-limited (429), so auth is resilient

## Test plan

- [x] All 287 tests pass
- [x] `ruff check` and `ruff format` pass
- [x] Manual smoke test: `fit-file-faker -u -d tests/files/mywhoosh_20260111.fit` authenticated successfully via `widget+cffi` fallback strategy
- [x] Full upload test: `fit-file-faker -u tests/files/mywhoosh_20260111.fit` uploaded successfully to Garmin Connect
- [x] Token cached to `~/Library/Application Support/FitFileFaker/.garmin_<profile>/garmin_tokens.json`