### PR TITLE
Support Garmin MFA login and add .fit suffix to temp upload files

### DIFF
--- a/fit_file_faker/app.py
+++ b/fit_file_faker/app.py
@@ -209,7 +209,9 @@ class NewFileEventHandler(PatternMatchingEventHandler):
                 source_file = Path(p).absolute()
 
                 # Edit the file and upload it
-                with NamedTemporaryFile(delete=True, delete_on_close=False) as fp:
+                with NamedTemporaryFile(
+                    delete=True, delete_on_close=False, suffix=".fit"
+                ) as fp:
                     fit_editor.set_profile(self.profile)
                     output = fit_editor.edit_fit(source_file, output=Path(fp.name))
                     if output:
@@ -291,7 +293,20 @@ def upload(
             "Run with --config-menu to update the profile."
         )
 
-    client = Garmin(email, password)
+    def _prompt_mfa() -> str:
+        _logger.info(
+            "Garmin Connect requires a multi-factor authentication code "
+            "(check your email or authenticator app)"
+        )
+        return (
+            questionary.text(
+                "MFA code:",
+                validate=lambda v: bool(v.strip()) or "MFA code cannot be empty",
+            ).ask()
+            or ""
+        )
+
+    client = Garmin(email, password, prompt_mfa=_prompt_mfa)
     _logger.info("Authenticating to Garmin Connect")
     client.login(tokenstore=str(token_dir))
 
@@ -379,7 +394,9 @@ def upload_all(
         _logger.info(f'Processing "{f}"')  # type: ignore
 
         if not preinitialize:
-            with NamedTemporaryFile(delete=True, delete_on_close=False) as fp:
+            with NamedTemporaryFile(
+                delete=True, delete_on_close=False, suffix=".fit"
+            ) as fp:
                 fit_editor.set_profile(profile)
                 output = fit_editor.edit_fit(dir.joinpath(f), output=Path(fp.name))
                 if output:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -134,20 +134,6 @@ class TestUploadFunction:
         with pytest.raises(ValueError, match="missing Garmin credentials"):
             upload(tpv_fit_file, profile=mock_profile, dryrun=False)
 
-    def test_upload_passes_prompt_mfa(
-        self, tpv_fit_file, mock_garmin_client, mock_valid_config
-    ):
-        """Garmin() must receive a callable prompt_mfa so MFA-required logins work."""
-        mock_cls, _ = mock_garmin_client
-        mock_profile = mock_valid_config.config.get_default_profile()
-
-        upload(tpv_fit_file, profile=mock_profile, dryrun=True)
-
-        _, kwargs = mock_cls.call_args
-        assert callable(kwargs.get("prompt_mfa")), (
-            "Garmin() must be constructed with a prompt_mfa callback"
-        )
-
 
 class TestUploadAllFunction:
     """Tests for batch upload functionality."""

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -134,6 +134,20 @@ class TestUploadFunction:
         with pytest.raises(ValueError, match="missing Garmin credentials"):
             upload(tpv_fit_file, profile=mock_profile, dryrun=False)
 
+    def test_upload_passes_prompt_mfa(
+        self, tpv_fit_file, mock_garmin_client, mock_valid_config
+    ):
+        """Garmin() must receive a callable prompt_mfa so MFA-required logins work."""
+        mock_cls, _ = mock_garmin_client
+        mock_profile = mock_valid_config.config.get_default_profile()
+
+        upload(tpv_fit_file, profile=mock_profile, dryrun=True)
+
+        _, kwargs = mock_cls.call_args
+        assert callable(kwargs.get("prompt_mfa")), (
+            "Garmin() must be constructed with a prompt_mfa callback"
+        )
+
 
 class TestUploadAllFunction:
     """Tests for batch upload functionality."""

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -134,6 +134,30 @@ class TestUploadFunction:
         with pytest.raises(ValueError, match="missing Garmin credentials"):
             upload(tpv_fit_file, profile=mock_profile, dryrun=False)
 
+    @patch("fit_file_faker.app.questionary")
+    def test_upload_prompt_mfa_callback_delegates_to_questionary(
+        self, mock_questionary, tpv_fit_file, mock_garmin_client, mock_valid_config
+    ):
+        """The prompt_mfa callback passed to Garmin() must ask the user via
+        questionary and return the entered code.
+
+        Regression test: previously Garmin() was constructed without prompt_mfa,
+        so MFA-required logins failed with
+        "MFA Required but no prompt_mfa mechanism supplied".
+        """
+        mock_questionary.text.return_value.ask.return_value = "123456"
+        mock_cls, _ = mock_garmin_client
+        mock_profile = mock_valid_config.config.get_default_profile()
+
+        upload(tpv_fit_file, profile=mock_profile, dryrun=True)
+
+        prompt_mfa = mock_cls.call_args.kwargs.get("prompt_mfa")
+        assert callable(prompt_mfa), (
+            "Garmin() must be constructed with a prompt_mfa callback"
+        )
+        assert prompt_mfa() == "123456"
+        mock_questionary.text.assert_called_once()
+
 
 class TestUploadAllFunction:
     """Tests for batch upload functionality."""


### PR DESCRIPTION
Hello,
While running Fit-File-Faker on a fresh MyWhoosh profile I hit two issues:

### 1. MFA login support
`Garmin(email, password)` was constructed without a `prompt_mfa` callback. When Garmin's SSO required an MFA code, the underlying library raised:

```
GarminConnectAuthenticationError: MFA Required but no prompt_mfa mechanism supplied
```
I added a `prompt_mfa` callback that uses `questionary` (already a project dependency) to interactively ask the user for the one-time code. After a successful login, tokens are cached as before, so subsequent runs don't re-prompt.

## 2. Temp files must carry the `.fit` extension
Fix for:
```GarminConnectInvalidFileFormatError: File has no extension: /var/folders/g9/401mxzxx7cj89pmjyvmnw5c00000gn/T/tmp2g2z9cmi```

`garminconnect` validates the file extension in `upload_activity()` and rejects files without one. I added `suffix=".fit"` to both `NamedTemporaryFile(...)` calls in `upload_all()` and `NewFileEventHandler.on_created()`.