### PR TITLE
feat: estimate missing calories from power/HR data

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,7 @@ fit_file_faker/
 ├── __init__.py           # Package initialization (1 line)
 ├── app.py                # Main application, CLI, uploads, monitoring (550 lines)
 ├── app_registry.py       # NEW: Trainer app detection system (305 lines)
+├── calorie_calculator.py # Calorie estimation for files missing total_calories
 ├── config.py             # Configuration management (750 lines)
 ├── fit_editor.py         # FIT file editing core logic (313 lines)
 └── utils.py              # Utility functions and monkey patches (103 lines)
@@ -134,6 +135,13 @@ fit_file_faker/
 - Device info messages are similarly rewritten to Garmin Edge 830
 - Preserves activity data (records, laps, sessions) - only modifies device metadata
 - Special handling for Activity messages (reordered to end for COROS compatibility)
+- Optional calorie injection: when `Profile.recalculate_calories` is enabled, missing `total_calories` values are estimated via `calorie_calculator.py` and written into Session/Lap messages (existing values are never overwritten)
+
+**`calorie_calculator.py` - Calorie Estimation**
+- Estimates `total_calories` for FIT files that lack it (e.g., Hammerhead Karoo)
+- Power-based method (preferred): integrates power samples, converts kJ → kcal at 22% gross efficiency
+- HR-based fallback: Keytel et al. (2005) regression, requires `Profile.weight_kg`/`age`/`sex`
+- Returns session total plus a per-lap split (`CalorieResult`), consumed by `fit_editor.py`
 
 **`app_registry.py` - Trainer App Detection**
 - `AppDetector` ABC: Abstract base class for trainer app detection

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ A Python tool to modify [FIT](https://developer.garmin.com/fit/overview/) files 
 
 **Upload** edited files directly to Garmin Connect, or run in **monitor mode** for automatic uploads.
 
+**Estimate** calories burned for activities whose FIT files lack the value (e.g., from Hammerhead Karoo devices), using power data or a heart-rate-based fallback — see [Calorie Estimation](https://jat255.github.io/Fit-File-Faker/profiles/#calorie-estimation).
+
 ## 📖 Documentation
 
 For comprehensive documentation, visit: **https://jat255.github.io/Fit-File-Faker/**

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,8 @@ This application allows you to easily modify [FIT](https://developer.garmin.com/
 
 Additionally, it can be run in a "monitor" mode that will watch a folder for new FIT files and will automatically edit/upload them as they are produced. One potential application of this mode is to have the tool auto-start on the computer that you use for indoor training, so rides are automatically uploaded to Garmin Connect when you finish.
 
+The tool can also estimate calories burned for activities whose FIT files lack the value (e.g., from Hammerhead Karoo devices), using power data or a heart-rate-based fallback — see [Calorie Estimation](profiles.md#calorie-estimation) for details.
+
 ## Feature walkthrough
 
 <div align="center">

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -93,12 +93,18 @@ The ⭐ symbol indicates the default profile.
      - Enter Garmin username (email)
      - Enter Garmin password (masked input)
 
-4. **Profile Name**:
+4. **Calorie Estimation (optional)**:
+
+     - Enable estimation of calories burned for FIT files that lack the value
+       (see [Calorie Estimation](#calorie-estimation))
+     - Optionally provide weight/age/sex for the heart-rate-based fallback
+
+5. **Profile Name**:
    
      - Suggested name based on app type (e.g., "tpv", "zwift")
      - Option to customize name
 
-5. **Confirm & Save**: Review all settings and confirm
+6. **Confirm & Save**: Review all settings and confirm
 
 #### Example: Creating a Zwift Profile
 
@@ -222,6 +228,36 @@ For unsupported trainer apps or custom setups:
 - No auto-detection
 - Full flexibility for any FIT file source
 
+## Calorie Estimation
+
+Some devices and platforms — most notably the Hammerhead Karoo — do not write a `total_calories` value to their FIT files. When such a file is uploaded, Garmin Connect displays the activity with 0 kcal, which also skews daily calorie totals and the nutrition module.
+
+FIT File Faker can estimate the missing value from the data already recorded in the file and write it into the session and lap messages. The feature is **opt-in per profile** and only fills in *missing* values — activities that already contain calorie data are never modified.
+
+### Estimation Methods
+
+Two methods are supported, in order of preference:
+
+1. **Power-based** (used when at least half of the records contain valid power data): the total mechanical work is integrated from the power samples and converted to metabolic energy assuming a gross efficiency of 22% (`1 kJ of work ≈ 1.086 kcal`), the convention also used by Hammerhead, Garmin, and Strava. No personal data is required.
+2. **Heart-rate-based fallback** (used when power data is unavailable): the Keytel et al. (2005) regression, which requires your weight, age, and sex. These values are stored in the profile and are not used for anything else.
+
+If the power meter drops out mid-ride, the affected samples are filled in using the heart-rate method (when weight, age, and sex are configured), so the estimate does not undercount the power-less part of the activity.
+
+If neither method is applicable (no power data, and no anthropometric data configured), the file is processed normally and a warning is logged.
+
+### Enabling Calorie Estimation
+
+Enable the feature during profile creation, or later via `fit-file-faker --config-menu` → "Edit existing profile". The profiles table (`--list-profiles`) shows which profiles have it enabled in the "Kcal est." column.
+
+### Configuration Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `recalculate_calories` | bool | Enables the feature for this profile (default: `false`) |
+| `weight_kg` | float | Body weight in kilograms (HR fallback only) |
+| `age` | int | Age in years (HR fallback only) |
+| `sex` | string | `"male"` or `"female"` (HR fallback only) |
+
 ## Credential Isolation
 
 ### How It Works
@@ -268,7 +304,11 @@ The configuration file is stored in your platform's user config directory:
       "app_type": "zwift",
       "garmin_username": "personal@gmail.com",
       "garmin_password": "secret456",
-      "fitfiles_path": "/Users/test/Documents/Zwift/Activities"
+      "fitfiles_path": "/Users/test/Documents/Zwift/Activities",
+      "recalculate_calories": true,
+      "weight_kg": 75.0,
+      "age": 40,
+      "sex": "male"
     }
   ],
   "default_profile": "zwift"

--- a/fit_file_faker/calorie_calculator.py
+++ b/fit_file_faker/calorie_calculator.py
@@ -1,0 +1,299 @@
+"""Estimate total calories for FIT activities missing the value.
+
+Some bike computers (notably Hammerhead Karoo) record activity data without
+populating `total_calories` in `SessionMessage`/`LapMessage`. When the file
+is uploaded to Garmin Connect those activities show up with 0 kcal, which
+breaks downstream calculations like daily totals and the nutrition module.
+
+This module re-derives calories from per-record samples already present in
+the file. Two methods are supported, in order of preference:
+
+1. **Power-based** — integrate `RecordMessage.power` over time to get the
+   total mechanical work in kJ, then convert to metabolic kcal assuming a
+   gross efficiency of 22% (`1 kJ work × 1 / (0.22 × 4.184) ≈ 1.086 kcal`;
+   see `_GROSS_EFFICIENCY`). No anthropometric input needed.
+
+2. **HR-based fallback** — Keytel et al. (2005) regression on
+   `RecordMessage.heart_rate`, requiring the rider's weight, age, and sex.
+
+When the power method is selected but the meter drops out mid-activity, the
+affected intervals are individually filled from heart rate (when the profile
+provides the HR inputs) instead of counting zero work.
+
+The chosen method, the session total, and a per-lap breakdown are returned
+together so the editor can write them into both `SessionMessage` and the
+individual `LapMessage` records.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Sequence
+
+from fit_file_faker.vendor.fit_tool.profile.messages.lap_message import LapMessage
+from fit_file_faker.vendor.fit_tool.profile.messages.record_message import (
+    RecordMessage,
+)
+
+_logger = logging.getLogger("garmin")
+
+# Max gap between two consecutive samples that we still treat as "recording".
+# Longer gaps are assumed to be pauses and are clamped to this value, so a
+# pause contributes at most 30 s worth of energy at the resuming sample.
+_MAX_SAMPLE_GAP_S = 30.0
+
+# Minimum fraction of records that must carry a valid reading of the signal
+# (power or heart rate) for the corresponding method to be chosen.
+_COVERAGE_THRESHOLD = 0.5
+
+# Plausibility bounds for individual samples. Devices often emit the FIT
+# spec's "invalid uint16" marker (65535 for power, 255 for HR) when a
+# sensor briefly drops out; fit_tool sometimes lets those through as real
+# values. We also reject obviously absurd readings to keep the integral
+# robust against single-sample spikes.
+_POWER_MAX_W = 2000  # world-class sprinters peak ~2500W, anything beyond is noise
+_HR_MIN_BPM = 30
+_HR_MAX_BPM = 230
+
+# Cyclist gross efficiency: ratio of mechanical work to metabolic energy.
+# 22% is the de facto industry standard used by Hammerhead, Garmin Edge,
+# Strava and most recreational-cycling tools (a small handful of training
+# platforms use 24% which targets elite riders). Coyle et al. (1991) and
+# Moseley & Jeukendrup (2001) report measured GE in the 20-25% range.
+_GROSS_EFFICIENCY = 0.22
+# Multiplier from kJ of mechanical work to kcal of metabolic expenditure:
+#   kcal = J / GE / 4184 = kJ / (GE * 4.184)
+# For GE = 0.22 this works out to ~1.0861.
+_KJ_TO_KCAL = 1.0 / (_GROSS_EFFICIENCY * 4.184)
+
+
+def _valid_power(p):
+    return p is not None and 0 <= p <= _POWER_MAX_W
+
+
+def _valid_hr(hr):
+    return hr is not None and _HR_MIN_BPM <= hr <= _HR_MAX_BPM
+
+
+def _has_hr_inputs(profile) -> bool:
+    """Whether the profile carries everything the Keytel formula needs."""
+    return (
+        profile is not None
+        and profile.weight_kg is not None
+        and profile.age is not None
+        and profile.sex in ("male", "female")
+    )
+
+
+@dataclass
+class CalorieResult:
+    """Outcome of a calorie estimation run."""
+
+    total_calories: int
+    per_lap_calories: list[int]
+    method: str  # "power" | "hr" | "none"
+    reason: str
+
+
+def calculate_from_records(
+    records: Sequence[RecordMessage],
+    laps: Sequence[LapMessage],
+    profile,
+) -> CalorieResult:
+    """Estimate session and per-lap calories from raw FIT records.
+
+    Args:
+        records: All `RecordMessage` instances from the file, in original
+            order (assumed to be chronological).
+        laps: All `LapMessage` instances from the file, in original order.
+        profile: A `Profile` object. Only the anthropometric fields
+            (`weight_kg`, `age`, `sex`) are consulted, and only when the
+            HR-based fallback is used.
+
+    Returns:
+        A `CalorieResult` with `method="none"` if there isn't enough data
+        to estimate; otherwise the session total and a per-lap split.
+    """
+    timed = [r for r in records if r.timestamp is not None]
+    if len(timed) < 2:
+        return CalorieResult(0, [], "none", "fewer than 2 timestamped records")
+
+    method = _choose_method(timed, profile)
+    if method == "none":
+        return CalorieResult(
+            0,
+            [],
+            "none",
+            "no power data and HR fallback inputs (weight/age/sex) missing",
+        )
+
+    per_sample_kcal, hr_filled = _per_sample_kcal(timed, method, profile)
+    total = int(round(sum(per_sample_kcal)))
+
+    per_lap = _split_by_lap(timed, per_sample_kcal, laps, total) if laps else []
+
+    reason = f"computed from {len(timed)} samples using {method}"
+    if hr_filled:
+        reason += f", {hr_filled} samples filled from HR"
+
+    return CalorieResult(
+        total_calories=total,
+        per_lap_calories=per_lap,
+        method=method,
+        reason=reason,
+    )
+
+
+def _choose_method(records: Sequence[RecordMessage], profile) -> str:
+    """Decide between power, hr, or none based on data and profile."""
+    with_power = sum(1 for r in records if _valid_power(r.power))
+    if with_power / len(records) >= _COVERAGE_THRESHOLD:
+        return "power"
+
+    if _has_hr_inputs(profile):
+        with_hr = sum(1 for r in records if _valid_hr(r.heart_rate))
+        if with_hr / len(records) >= _COVERAGE_THRESHOLD:
+            return "hr"
+
+    return "none"
+
+
+def _per_sample_kcal(
+    records: Sequence[RecordMessage], method: str, profile
+) -> tuple[list[float], int]:
+    """Compute calories attributed to each sample interval.
+
+    The energy for record `i` covers the gap `[record[i-1], record[i]]`. The
+    first record produces zero energy because there is no preceding interval.
+
+    The power method integrates trapezoidally (mean of the two endpoint
+    readings) when both endpoints are valid; a single valid endpoint is used
+    as-is, which smooths over brief sensor dropouts. When neither endpoint
+    has power (e.g., the meter died mid-ride), the interval is estimated from
+    heart rate via the Keytel formula, provided the profile carries the
+    required weight/age/sex — otherwise it contributes zero.
+
+    Returns:
+        Tuple of (per-sample kcal list, number of power-method intervals
+        that were filled from heart rate).
+    """
+    out: list[float] = [0.0]
+    hr_filled = 0
+    can_fall_back_to_hr = _has_hr_inputs(profile)
+    for i in range(1, len(records)):
+        prev = records[i - 1]
+        cur = records[i]
+        dt = max(0.0, min(_MAX_SAMPLE_GAP_S, (cur.timestamp - prev.timestamp) / 1000.0))
+        if dt == 0.0:
+            out.append(0.0)
+            continue
+
+        if method == "power":
+            prev_ok = _valid_power(prev.power)
+            cur_ok = _valid_power(cur.power)
+            if prev_ok and cur_ok:
+                watts = (prev.power + cur.power) / 2.0
+            elif prev_ok or cur_ok:
+                watts = prev.power if prev_ok else cur.power
+            elif can_fall_back_to_hr and _valid_hr(cur.heart_rate):
+                # Power meter dropout: estimate this interval from HR instead
+                # of counting zero work.
+                hr_filled += 1
+                out.append(_keytel_kcal_per_min(cur.heart_rate, profile) * dt / 60.0)
+                continue
+            else:
+                out.append(0.0)
+                continue
+            # kJ of mechanical work → kcal of metabolic expenditure, using
+            # GE = 22% (industry default; see _GROSS_EFFICIENCY above).
+            out.append(watts * dt / 1000.0 * _KJ_TO_KCAL)
+        else:  # hr
+            if not _valid_hr(cur.heart_rate):
+                out.append(0.0)
+                continue
+            out.append(_keytel_kcal_per_min(cur.heart_rate, profile) * dt / 60.0)
+
+    return out, hr_filled
+
+
+def _keytel_kcal_per_min(hr: int, profile) -> float:
+    """Keytel et al. (2005) calorie expenditure regression.
+
+    Returns kcal/minute for an instantaneous heart rate sample.
+    """
+    weight = profile.weight_kg
+    age = profile.age
+    if profile.sex == "male":
+        # kJ/min → kcal/min via /4.184
+        return max(
+            0.0,
+            (-55.0969 + 0.6309 * hr + 0.1988 * weight + 0.2017 * age) / 4.184,
+        )
+    # female
+    return max(
+        0.0,
+        (-20.4022 + 0.4472 * hr - 0.1263 * weight + 0.074 * age) / 4.184,
+    )
+
+
+def _split_by_lap(
+    records: Sequence[RecordMessage],
+    per_sample_kcal: Sequence[float],
+    laps: Sequence[LapMessage],
+    total: int,
+) -> list[int]:
+    """Distribute the per-sample energy across the given laps.
+
+    A sample is attributed to the first lap whose `[start_time, end_time]`
+    range contains its timestamp. Records before any lap (which is rare but
+    possible) are attributed to the first lap; records after the last lap
+    end up in the last lap. The result is then renormalized so its sum
+    matches the session total exactly (compensates for rounding).
+    """
+    ranges: list[tuple[int, int]] = []
+    for lap in laps:
+        start = lap.start_time
+        end = lap.timestamp
+        if start is None or end is None:
+            # Fall back to elapsed-time math if endpoints missing.
+            if start is None and end is not None and lap.total_elapsed_time is not None:
+                start = int(end - lap.total_elapsed_time * 1000)
+            elif (
+                end is None and start is not None and lap.total_elapsed_time is not None
+            ):
+                end = int(start + lap.total_elapsed_time * 1000)
+            else:
+                ranges.append((0, 0))
+                continue
+        ranges.append((start, end))
+
+    buckets = [0.0] * len(laps)
+    for rec, kcal in zip(records, per_sample_kcal):
+        if kcal == 0.0:
+            continue
+        ts = rec.timestamp
+        idx = _lap_index_for_timestamp(ts, ranges)
+        buckets[idx] += kcal
+
+    rounded = [int(round(b)) for b in buckets]
+    drift = total - sum(rounded)
+    if rounded:
+        rounded[-1] += drift
+    return rounded
+
+
+def _lap_index_for_timestamp(ts: int, ranges: Sequence[tuple[int, int]]) -> int:
+    """Return the lap index this timestamp belongs to.
+
+    Timestamps that fall between laps (e.g., a recording pause spanning a lap
+    boundary) or before the first lap are attributed to the next lap to
+    start; anything after the last lap goes to the last lap.
+    """
+    for i, (start, end) in enumerate(ranges):
+        if start <= ts <= end:
+            return i
+    for i, (start, _end) in enumerate(ranges):
+        if ts < start:
+            return i
+    return len(ranges) - 1

--- a/fit_file_faker/config.py
+++ b/fit_file_faker/config.py
@@ -32,7 +32,7 @@ import sys
 from dataclasses import asdict, dataclass
 from enum import Enum
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 import questionary
 from platformdirs import PlatformDirs
@@ -637,6 +637,13 @@ class Profile:
         serial_number: Device serial number (should be the device's Unit ID; auto-generated if not specified)
         software_version: Firmware version in FIT format (e.g., 2922 = v29.22). If None,
             no FileCreatorMessage will be added to FIT files.
+        recalculate_calories: If True, the editor estimates total_calories for
+            Session/Lap messages that are missing it (power-first, HR-fallback).
+            Useful for devices like Hammerhead Karoo that don't write calories.
+        weight_kg: Body weight in kilograms; required only for the HR-based
+            fallback (Keytel formula). Optional otherwise.
+        age: Age in years; required only for the HR-based fallback.
+        sex: "male" or "female"; required only for the HR-based fallback.
 
     Examples:
         >>> from pathlib import Path
@@ -658,6 +665,10 @@ class Profile:
     device: int | None = None
     serial_number: int | None = None
     software_version: int | None = None
+    recalculate_calories: bool = False
+    weight_kg: float | None = None
+    age: int | None = None
+    sex: str | None = None
 
     def __post_init__(self):
         """Convert string types to proper objects after initialization.
@@ -1293,6 +1304,26 @@ def get_tpv_folder(default_path: Path | None) -> Path:
     return Path(TPVPath)
 
 
+_LBS_TO_KG = 0.45359237
+
+# Sentinel for "argument not provided" in update_profile, so that None can be
+# passed explicitly to clear an optional field (e.g. weight_kg/age/sex).
+_UNSET: Any = object()
+
+
+def _validate_weight(value: str, unit: str = "kg") -> bool:
+    """Accept any decimal weight in the plausible human range.
+
+    The plausible human range is 20-300 kg (≈ 44-661 lbs).
+    """
+    try:
+        amount = float(value)
+    except (TypeError, ValueError):
+        return False
+    kg = amount * _LBS_TO_KG if unit == "lbs" else amount
+    return 20.0 <= kg <= 300.0
+
+
 class ProfileManager:
     """Manages profile CRUD operations and TUI interactions.
 
@@ -1322,6 +1353,10 @@ class ProfileManager:
         device: int | None = None,
         serial_number: int | None = None,
         software_version: int | None = None,
+        recalculate_calories: bool = False,
+        weight_kg: float | None = None,
+        age: int | None = None,
+        sex: str | None = None,
     ) -> Profile:
         """Create a new profile and add it to config.
 
@@ -1376,6 +1411,10 @@ class ProfileManager:
             device=device,
             serial_number=serial_number,
             software_version=software_version,
+            recalculate_calories=recalculate_calories,
+            weight_kg=weight_kg,
+            age=age,
+            sex=sex,
         )
 
         # Validate serial number if provided
@@ -1425,6 +1464,10 @@ class ProfileManager:
         device: int | None = None,
         serial_number: int | None = None,
         software_version: int | None = None,
+        recalculate_calories: bool | None = None,
+        weight_kg: float | None = _UNSET,
+        age: int | None = _UNSET,
+        sex: str | None = _UNSET,
     ) -> Profile:
         """Update an existing profile.
 
@@ -1439,6 +1482,10 @@ class ProfileManager:
             device: New device ID (optional).
             serial_number: New serial number (optional).
             software_version: New firmware version in FIT format (optional).
+            recalculate_calories: New calorie recalculation setting; None keeps
+                the current value.
+            weight_kg: New body weight in kg. Omit to keep the current value;
+                pass None explicitly to clear it. Same for `age` and `sex`.
 
         Returns:
             The updated Profile object.
@@ -1494,6 +1541,14 @@ class ProfileManager:
             profile.serial_number = serial_number
         if software_version is not None:
             profile.software_version = software_version
+        if recalculate_calories is not None:
+            profile.recalculate_calories = recalculate_calories
+        if weight_kg is not _UNSET:
+            profile.weight_kg = weight_kg
+        if age is not _UNSET:
+            profile.age = age
+        if sex is not _UNSET:
+            profile.sex = sex
 
         # Update default_profile if name changed
         if new_name and self.config_manager.config.default_profile == name:
@@ -1567,6 +1622,7 @@ class ProfileManager:
         table.add_column("App", style="blue")
         table.add_column("Device", style="cyan")
         table.add_column("Serial #", style="bright_blue")
+        table.add_column("Kcal est.", style="cyan", justify="center")
         table.add_column("Garmin User", style="yellow")
         table.add_column("FIT Path", style="magenta")
 
@@ -1595,6 +1651,9 @@ class ProfileManager:
                 str(profile.serial_number) if profile.serial_number else "N/A"
             )
 
+            # Calorie recalculation status
+            kcal_display = "✓" if profile.recalculate_calories else "—"
+
             # Truncate long paths
             path_str = str(profile.fitfiles_path)
             if len(path_str) > 40:
@@ -1605,6 +1664,7 @@ class ProfileManager:
                 app_display,
                 device_display,
                 serial_display,
+                kcal_display,
                 profile.garmin_username,
                 path_str,
             )
@@ -1652,6 +1712,123 @@ class ProfileManager:
             except (KeyboardInterrupt, EOFError):
                 console.print("\n[yellow]Operation cancelled.[/yellow]")
                 continue
+
+    def _prompt_calorie_settings(
+        self,
+        console: "Console",
+        current_recalculate: bool = False,
+        current_weight_kg: float | None = None,
+        current_age: int | None = None,
+        current_sex: str | None = None,
+    ) -> tuple[bool, float | None, int | None, str | None]:
+        """Ask the user whether to enable calorie recalculation and gather HR inputs.
+
+        Some bike computers (e.g., Hammerhead Karoo) don't write `total_calories`
+        to FIT files. Fit File Faker can estimate the value from power and HR
+        data already in the file, so Garmin Connect can use it for daily totals
+        and nutrition.
+
+        When called from the edit wizard, the `current_*` parameters seed the
+        prompts so the user sees their existing values as defaults and Enter-
+        through-the-wizard doesn't silently wipe them.
+
+        Returns:
+            Tuple of (recalculate_calories, weight_kg, age, sex) describing the
+            complete desired state — callers should apply it wholesale. None
+            for weight/age/sex means "not stored": when stored values exist and
+            the user answers No to keeping them, they are cleared. Cancelled
+            prompts (Ctrl+C / empty answer) return the current values instead,
+            so cancelling never wipes stored data.
+        """
+        console.print("\n[bold cyan]Calorie recalculation (optional)[/bold cyan]")
+        console.print(
+            "Some devices (e.g., Hammerhead Karoo) leave the FIT file without\n"
+            "an estimate of calories burned. Fit File Faker can compute it from\n"
+            "the recorded samples and write it into the file, so Garmin Connect\n"
+            "can use it for daily totals and the nutrition module.\n\n"
+            "[dim]Strategy:[/dim]\n"
+            "[dim]  1) If the file has power data → power-based (most accurate)[/dim]\n"
+            "[dim]  2) Otherwise → HR-based (Keytel formula; needs weight/age/sex)[/dim]"
+        )
+
+        enable = questionary.confirm(
+            "Enable calorie recalculation for this profile?",
+            default=current_recalculate,
+        ).ask()
+        if not enable:
+            # Keep any stored anthropometrics so toggling the feature back on
+            # later doesn't require re-entering them.
+            return (False, current_weight_kg, current_age, current_sex)
+
+        has_hr_inputs = (
+            current_weight_kg is not None
+            and current_age is not None
+            and current_sex in ("male", "female")
+        )
+        if has_hr_inputs:
+            hr_question = (
+                "Keep/update weight/age/sex for the HR-based fallback? "
+                "(answering No removes them from the profile)"
+            )
+        else:
+            hr_question = (
+                "Provide weight/age/sex for the HR-based fallback? "
+                "(skip if you only ride with power)"
+            )
+        provide_hr = questionary.confirm(
+            hr_question,
+            default=True if not current_recalculate else has_hr_inputs,
+        ).ask()
+        if not provide_hr:
+            return (True, None, None, None)
+
+        weight_unit = questionary.select(
+            "Weight unit:", choices=["kg", "lbs"], default="kg"
+        ).ask()
+        if not weight_unit:
+            return (True, current_weight_kg, current_age, current_sex)
+
+        # Pre-fill the prompt with the stored kg value (only when the user
+        # didn't switch unit — converting back to lbs would just look weird).
+        weight_default = (
+            f"{current_weight_kg:g}"
+            if current_weight_kg is not None and weight_unit == "kg"
+            else ""
+        )
+        weight_input = questionary.text(
+            f"Body weight ({weight_unit}):",
+            default=weight_default,
+            validate=lambda x: _validate_weight(x, weight_unit)
+            or f"Enter a number between {20 if weight_unit == 'kg' else 44} "
+            f"and {300 if weight_unit == 'kg' else 661}",
+        ).ask()
+        if not weight_input:
+            return (True, current_weight_kg, current_age, current_sex)
+
+        weight_kg = float(weight_input)
+        if weight_unit == "lbs":
+            weight_kg *= _LBS_TO_KG
+        # Round to 0.1 kg — Keytel coefficient × 0.1 kg ≈ 0.02 kcal/min
+        # impact, so storing more precision is just float noise.
+        weight_kg = round(weight_kg, 1)
+
+        age_default = str(current_age) if current_age is not None else ""
+        age_input = questionary.text(
+            "Age (years):",
+            default=age_default,
+            validate=lambda x: (x.isdigit() and 10 <= int(x) <= 120)
+            or "Enter a whole number between 10 and 120",
+        ).ask()
+        if not age_input:
+            return (True, weight_kg, current_age, current_sex)
+
+        sex = questionary.select(
+            "Sex (for Keytel formula):",
+            choices=["male", "female"],
+            default=current_sex if current_sex in ("male", "female") else None,
+        ).ask()
+
+        return (True, weight_kg, int(age_input), sex or current_sex)
 
     def create_profile_wizard(self) -> Profile | None:
         """Interactive wizard for creating a new profile.
@@ -1976,7 +2153,12 @@ class ProfileManager:
             "[dim](You can change these later via the edit profile menu)[/dim]"
         )
 
-        # Step 5: Profile name
+        # Step 5: Calorie recalculation (optional)
+        recalculate_calories, weight_kg, age, sex = self._prompt_calorie_settings(
+            console
+        )
+
+        # Step 6: Profile name
         suggested_name = app_type.value.split("_")[0].lower()
         profile_name = questionary.text(
             "Enter profile name:", default=suggested_name, validate=lambda x: len(x) > 0
@@ -1996,6 +2178,10 @@ class ProfileManager:
                 device=device,
                 serial_number=serial_number,
                 software_version=software_version,
+                recalculate_calories=recalculate_calories,
+                weight_kg=weight_kg,
+                age=age,
+                sex=sex,
             )
             console.print(
                 f"\n[green]✓ Profile '{profile_name}' created successfully![/green]"
@@ -2299,6 +2485,32 @@ class ProfileManager:
                     if serial_input and serial_input.isdigit():
                         new_serial = int(serial_input)
 
+        # Edit calorie recalculation settings. weight/age/sex default to _UNSET
+        # ("don't touch") — when the user walks through the calorie prompts,
+        # the returned tuple is applied wholesale, so None values clear the
+        # stored anthropometrics.
+        new_recalc: bool | None = None
+        new_weight: float | None = _UNSET
+        new_age: int | None = _UNSET
+        new_sex: str | None = _UNSET
+        current_state = "on" if profile.recalculate_calories else "off"
+        if questionary.confirm(
+            f"Edit calorie recalculation settings? (currently {current_state})",
+            default=False,
+        ).ask():
+            (
+                new_recalc,
+                new_weight,
+                new_age,
+                new_sex,
+            ) = self._prompt_calorie_settings(
+                console,
+                current_recalculate=profile.recalculate_calories,
+                current_weight_kg=profile.weight_kg,
+                current_age=profile.age,
+                current_sex=profile.sex,
+            )
+
         # Update profile with provided values
         try:
             self.update_profile(
@@ -2311,6 +2523,10 @@ class ProfileManager:
                 device=new_device,
                 serial_number=new_serial,
                 software_version=new_software_version,
+                recalculate_calories=new_recalc,
+                weight_kg=new_weight,
+                age=new_age,
+                sex=new_sex,
             )
             console.print("\n[green]✓ Profile updated successfully![/green]")
         except ValueError as e:

--- a/fit_file_faker/fit_editor.py
+++ b/fit_file_faker/fit_editor.py
@@ -21,6 +21,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
+from fit_file_faker import calorie_calculator
 from fit_file_faker.vendor.fit_tool.definition_message import DefinitionMessage
 from fit_file_faker.vendor.fit_tool.fit_file import FitFile
 from fit_file_faker.vendor.fit_tool.fit_file_builder import FitFileBuilder
@@ -35,6 +36,13 @@ from fit_file_faker.vendor.fit_tool.profile.messages.file_creator_message import
 )
 from fit_file_faker.vendor.fit_tool.profile.messages.file_id_message import (
     FileIdMessage,
+)
+from fit_file_faker.vendor.fit_tool.profile.messages.lap_message import LapMessage
+from fit_file_faker.vendor.fit_tool.profile.messages.record_message import (
+    RecordMessage,
+)
+from fit_file_faker.vendor.fit_tool.profile.messages.session_message import (
+    SessionMessage,
 )
 from fit_file_faker.vendor.fit_tool.profile.messages.software_message import (
     SoftwareMessage,
@@ -457,6 +465,33 @@ class FitEditor:
                 _logger.error("Output path required when using parsed FIT file")
                 return None
 
+        # Pre-pass: if the profile asks for calorie recalculation, estimate
+        # totals from RecordMessages now so we can inject them when we
+        # encounter Session/Lap in the main loop.
+        kcal_result = None
+        lap_counter = 0
+        if self.profile and getattr(self.profile, "recalculate_calories", False):
+            records = [
+                r.message
+                for r in fit_file.records
+                if isinstance(r.message, RecordMessage)
+            ]
+            laps = [
+                r.message for r in fit_file.records if isinstance(r.message, LapMessage)
+            ]
+            kcal_result = calorie_calculator.calculate_from_records(
+                records, laps, self.profile
+            )
+            if kcal_result.method == "none":
+                _logger.warning(
+                    f"Calorie recalculation requested but skipped: {kcal_result.reason}"
+                )
+            else:
+                _logger.info(
+                    f"Calorie recalculation: total={kcal_result.total_calories} kcal "
+                    f"(method={kcal_result.method}, {kcal_result.reason})"
+                )
+
         builder = FitFileBuilder(auto_define=True)
         skipped_device_type_zero = False
 
@@ -551,6 +586,36 @@ class FitEditor:
                         message.product_name = ""
                         self.print_message(f"    New Record: {i}", message)
 
+            if (
+                kcal_result is not None
+                and kcal_result.method != "none"
+                and isinstance(message, SessionMessage)
+                and not message.total_calories
+            ):
+                _inject_total_calories(message, kcal_result.total_calories)
+                _logger.info(
+                    f"Set SessionMessage.total_calories={kcal_result.total_calories} "
+                    f"(method={kcal_result.method})"
+                )
+
+            if (
+                kcal_result is not None
+                and kcal_result.method != "none"
+                and isinstance(message, LapMessage)
+                and kcal_result.per_lap_calories
+            ):
+                idx = lap_counter
+                lap_counter += 1
+                if (
+                    idx < len(kcal_result.per_lap_calories)
+                    and not message.total_calories
+                ):
+                    _inject_total_calories(message, kcal_result.per_lap_calories[idx])
+                    _logger.debug(
+                        f"Set LapMessage[{idx}].total_calories="
+                        f"{kcal_result.per_lap_calories[idx]}"
+                    )
+
             builder.add(message)
 
         # Add Activity messages at the end to ensure proper FIT file structure
@@ -573,6 +638,36 @@ class FitEditor:
             )
 
         return output
+
+
+def _inject_total_calories(message, value: int) -> None:
+    """Write `total_calories` into a Session/Lap message that didn't declare it.
+
+    `fit_tool` rejects setter calls when the field's `growable` flag is False —
+    this happens whenever the source file's definition message didn't include
+    the field. We flip the flag, set the value, and clear the cached
+    `definition_message` so `FitFileBuilder(auto_define=True)` regenerates a
+    fresh definition that includes the newly populated field.
+    """
+    if isinstance(message, SessionMessage):
+        from fit_file_faker.vendor.fit_tool.profile.messages.session_message import (
+            SessionTotalCaloriesField,
+        )
+
+        field_id = SessionTotalCaloriesField.ID
+    else:
+        from fit_file_faker.vendor.fit_tool.profile.messages.lap_message import (
+            LapTotalCaloriesField,
+        )
+
+        field_id = LapTotalCaloriesField.ID
+
+    field = message.get_field(field_id)
+    if field is None:
+        return
+    field.growable = True
+    message.total_calories = int(value)
+    message.definition_message = None
 
 
 # Global FIT editor instance

--- a/tests/test_calorie_calculator.py
+++ b/tests/test_calorie_calculator.py
@@ -172,6 +172,84 @@ class TestCalculateFromRecords:
         assert sum(result.per_lap_calories) == result.total_calories
         assert result.per_lap_calories[0] >= result.per_lap_calories[1]
 
+    def test_duplicate_timestamp_contributes_zero(self):
+        # Two consecutive samples with the same timestamp (dt=0) must not
+        # blow up or contribute energy for that interval.
+        records = [
+            _rec(0, power=200),
+            _rec(0, power=200),
+            _rec(10_000, power=200),
+        ]
+        result = calculate_from_records(records, laps=[], profile=_profile())
+        assert result.method == "power"
+        # Only the second interval (10 s @ 200 W) contributes: 2 kJ -> ~2 kcal.
+        assert result.total_calories == round(200 * 10 / 1000 * (1 / (0.22 * 4.184)))
+
+    def test_hr_method_skips_invalid_sample(self):
+        # HR method chosen (coverage >= 50%), but one sample in the middle
+        # reports an out-of-range HR value and must contribute zero.
+        records = [_rec(i * 1000, hr=150) for i in range(300)]
+        records.append(_rec(300_000, hr=255))  # invalid sentinel value
+        records += [_rec(i * 1000, hr=150) for i in range(301, 601)]
+        result = calculate_from_records(
+            records,
+            laps=[],
+            profile=_profile(weight_kg=70.0, age=30, sex="male"),
+        )
+        assert result.method == "hr"
+        # Should still be close to the all-valid HR estimate since only one
+        # sample's interval is dropped.
+        assert 130 <= result.total_calories <= 150
+
+    def test_keytel_female_formula_used(self):
+        records = [_rec(i * 1000, hr=140) for i in range(601)]
+        result = calculate_from_records(
+            records,
+            laps=[],
+            profile=_profile(weight_kg=60.0, age=28, sex="female"),
+        )
+        assert result.method == "hr"
+        assert result.total_calories > 0
+
+    def test_lap_missing_start_time_derives_from_elapsed(self):
+        # Lap has no start_time, but does have timestamp (end) and
+        # total_elapsed_time, so start should be derived from those.
+        records = [_rec(i * 1000, power=100) for i in range(601)]
+        laps = [_lap(None, 600_000, elapsed=600)]
+        result = calculate_from_records(records, laps=laps, profile=_profile())
+        assert len(result.per_lap_calories) == 1
+        assert result.per_lap_calories[0] == result.total_calories
+
+    def test_lap_missing_end_time_derives_from_elapsed(self):
+        # Lap has no timestamp (end), but does have start_time and
+        # total_elapsed_time, so end should be derived from those.
+        records = [_rec(i * 1000, power=100) for i in range(601)]
+        laps = [_lap(0, None, elapsed=600)]
+        result = calculate_from_records(records, laps=laps, profile=_profile())
+        assert len(result.per_lap_calories) == 1
+        assert result.per_lap_calories[0] == result.total_calories
+
+    def test_lap_missing_all_time_info_gets_empty_range(self):
+        # Lap has neither start/end nor elapsed time: falls back to an empty
+        # (0, 0) range rather than crashing, and still sums to the total.
+        records = [_rec(i * 1000, power=100) for i in range(601)]
+        laps = [_lap(None, None, elapsed=None)]
+        result = calculate_from_records(records, laps=laps, profile=_profile())
+        assert len(result.per_lap_calories) == 1
+        assert result.per_lap_calories[0] == result.total_calories
+
+    def test_sample_after_last_lap_goes_to_last_lap(self):
+        # Records extend 10 s past the final lap's end timestamp; those
+        # trailing samples must be attributed to the last lap.
+        records = [_rec(i * 1000, power=100) for i in range(611)]
+        laps = [
+            _lap(0, 300_000),
+            _lap(300_000, 600_000),
+        ]
+        result = calculate_from_records(records, laps=laps, profile=_profile())
+        assert sum(result.per_lap_calories) == result.total_calories
+        assert result.per_lap_calories[1] >= result.per_lap_calories[0]
+
 
 class TestCalorieResultDataclass:
     def test_default_field_types(self):

--- a/tests/test_calorie_calculator.py
+++ b/tests/test_calorie_calculator.py
@@ -1,0 +1,186 @@
+"""Tests for fit_file_faker.calorie_calculator.
+
+The calculator only reads `timestamp`, `power`, and `heart_rate` off the
+record objects and `start_time`/`timestamp` off lap objects. We use lightweight
+namespace stand-ins instead of constructing real fit_tool messages.
+"""
+
+from types import SimpleNamespace
+
+from fit_file_faker.calorie_calculator import (
+    CalorieResult,
+    _MAX_SAMPLE_GAP_S,
+    calculate_from_records,
+)
+
+
+def _rec(ts_ms, power=None, hr=None):
+    return SimpleNamespace(timestamp=ts_ms, power=power, heart_rate=hr)
+
+
+def _lap(start_ms, end_ms, elapsed=None):
+    return SimpleNamespace(
+        start_time=start_ms, timestamp=end_ms, total_elapsed_time=elapsed
+    )
+
+
+def _profile(weight_kg=None, age=None, sex=None):
+    return SimpleNamespace(
+        weight_kg=weight_kg,
+        age=age,
+        sex=sex,
+        recalculate_calories=True,
+    )
+
+
+class TestCalculateFromRecords:
+    def test_power_based_total_matches_kJ(self):
+        # 100 W sustained for 600 s = 60,000 J = 60 kJ.
+        # Metabolic conversion at GE = 22%: 60 / (0.22 * 4.184) ≈ 65 kcal.
+        records = [_rec(i * 1000, power=100) for i in range(601)]
+        result = calculate_from_records(records, laps=[], profile=_profile())
+        assert result.method == "power"
+        assert abs(result.total_calories - 65) <= 1
+
+    def test_zero_power_yields_zero_calories(self):
+        records = [_rec(i * 1000, power=0) for i in range(120)]
+        result = calculate_from_records(records, laps=[], profile=_profile())
+        assert result.method == "power"
+        assert result.total_calories == 0
+
+    def test_hr_fallback_when_power_missing(self):
+        # No power, but HR present and profile has anthropometrics.
+        # Male, 70 kg, 30 yr, HR 150 → roughly 13 kcal/min by Keytel.
+        records = [_rec(i * 1000, hr=150) for i in range(601)]
+        result = calculate_from_records(
+            records,
+            laps=[],
+            profile=_profile(weight_kg=70.0, age=30, sex="male"),
+        )
+        assert result.method == "hr"
+        # Keytel @ HR 150, 70 kg, 30 yr, male ≈ 14.2 kcal/min × 10 min ≈ 142 kcal
+        assert 135 <= result.total_calories <= 150
+
+    def test_returns_none_when_no_power_and_no_hr_inputs(self):
+        records = [_rec(i * 1000, hr=150) for i in range(30)]
+        # profile has neither weight nor age nor sex
+        result = calculate_from_records(records, laps=[], profile=_profile())
+        assert result.method == "none"
+        assert result.total_calories == 0
+
+    def test_returns_none_when_too_few_records(self):
+        result = calculate_from_records(
+            [_rec(0, power=200)], laps=[], profile=_profile()
+        )
+        assert result.method == "none"
+
+    def test_per_lap_split_sums_to_session_total(self):
+        # Two 5-minute laps at 100 W each → total ~60 kcal.
+        records = [_rec(i * 1000, power=100) for i in range(601)]
+        laps = [
+            _lap(0, 300_000),
+            _lap(300_000, 600_000),
+        ]
+        result = calculate_from_records(records, laps=laps, profile=_profile())
+        assert len(result.per_lap_calories) == 2
+        assert sum(result.per_lap_calories) == result.total_calories
+
+    def test_gap_in_recording_is_capped(self):
+        # Two samples 10 minutes apart shouldn't count as a 10-minute interval.
+        records = [_rec(0, power=200), _rec(600_000, power=200)]
+        result = calculate_from_records(records, laps=[], profile=_profile())
+        # Gap is clamped to _MAX_SAMPLE_GAP_S → 200 W * 30 s = 6 kJ.
+        # At GE = 22%: 6 / (0.22 * 4.184) ≈ 6.5 → 7 kcal.
+        kj = 200 * _MAX_SAMPLE_GAP_S / 1000
+        expected = round(kj / (0.22 * 4.184))
+        assert result.total_calories == expected
+
+    def test_trapezoidal_integration_between_sparse_samples(self):
+        # 0 W → 200 W over a 20 s gap. Trapezoidal mean is 100 W → 2 kJ
+        # → ~2.2 kcal. Right-rectangle integration would take 200 W → 4 kJ
+        # → ~4.3 kcal, so the rounded totals differ.
+        records = [_rec(0, power=0), _rec(20_000, power=200)]
+        result = calculate_from_records(records, laps=[], profile=_profile())
+        assert result.method == "power"
+        assert result.total_calories == 2
+
+    def test_single_sample_dropout_uses_valid_endpoint(self):
+        # Middle sample lost power (brief ANT+ dropout): both surrounding
+        # intervals still integrate using their one valid endpoint (200 W),
+        # so 2 × 200 W × 10 s = 4 kJ → ~4.3 → 4 kcal.
+        records = [
+            _rec(0, power=200),
+            _rec(10_000, power=None),
+            _rec(20_000, power=200),
+        ]
+        result = calculate_from_records(records, laps=[], profile=_profile())
+        assert result.method == "power"
+        assert result.total_calories == 4
+        assert "filled from HR" not in result.reason
+
+    def test_power_dropout_falls_back_to_hr_per_sample(self):
+        # Power meter dies halfway: first 5 min at 200 W (~65 kcal), second
+        # 5 min power-less but with HR 150 and a complete profile
+        # (~14 kcal/min by Keytel → ~70 kcal). Both halves must count.
+        records = [_rec(i * 1000, power=200) for i in range(301)]
+        records += [_rec(i * 1000, hr=150) for i in range(301, 601)]
+        result = calculate_from_records(
+            records,
+            laps=[],
+            profile=_profile(weight_kg=70.0, age=30, sex="male"),
+        )
+        assert result.method == "power"
+        assert "filled from HR" in result.reason
+        assert 125 <= result.total_calories <= 150
+
+    def test_power_dropout_without_hr_inputs_counts_zero(self):
+        # Same dropout but no anthropometrics in the profile: the power-less
+        # half contributes nothing, leaving just the first half (~65 kcal).
+        records = [_rec(i * 1000, power=200) for i in range(301)]
+        records += [_rec(i * 1000, hr=150) for i in range(301, 601)]
+        result = calculate_from_records(records, laps=[], profile=_profile())
+        assert result.method == "power"
+        assert "filled from HR" not in result.reason
+        assert 60 <= result.total_calories <= 70
+
+    def test_sample_between_laps_goes_to_next_lap(self):
+        # Three equal-effort thirds, but the lap ranges leave a 20 s hole
+        # between lap 1 and lap 2. Samples in the hole must land in lap 2
+        # (the next lap to start), not in the last lap.
+        records = [_rec(i * 1000, power=100) for i in range(601)]
+        laps = [
+            _lap(0, 200_000),
+            _lap(220_000, 400_000),
+            _lap(400_000, 600_000),
+        ]
+        result = calculate_from_records(records, laps=laps, profile=_profile())
+        assert sum(result.per_lap_calories) == result.total_calories
+        # With the hole attributed to lap 2, all three laps cover ~200 s of
+        # equal effort; the old "dump into last lap" behaviour would make
+        # lap 3 ~20 s heavier than lap 2.
+        lap_kcals = result.per_lap_calories
+        assert max(lap_kcals) - min(lap_kcals) <= 2
+
+    def test_sample_before_first_lap_goes_to_first_lap(self):
+        # 10 s of riding before the first lap starts must count towards it.
+        records = [_rec(i * 1000, power=100) for i in range(601)]
+        laps = [
+            _lap(10_000, 300_000),
+            _lap(300_000, 600_000),
+        ]
+        result = calculate_from_records(records, laps=laps, profile=_profile())
+        assert sum(result.per_lap_calories) == result.total_calories
+        assert result.per_lap_calories[0] >= result.per_lap_calories[1]
+
+
+class TestCalorieResultDataclass:
+    def test_default_field_types(self):
+        r = CalorieResult(
+            total_calories=42,
+            per_lap_calories=[10, 20, 12],
+            method="power",
+            reason="ok",
+        )
+        assert r.total_calories == 42
+        assert r.per_lap_calories == [10, 20, 12]
+        assert r.method == "power"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -904,6 +904,50 @@ class TestProfile:
         assert profile.app_type == AppType.MYWHOOSH
         assert profile.fitfiles_path == Path("/path/to/fitfiles")
 
+    def test_profile_calorie_fields_default_off(self):
+        """New calorie-related fields default to off / None."""
+        profile = Profile(
+            name="test",
+            app_type=AppType.ZWIFT,
+            garmin_username="u@x",
+            garmin_password="p",
+            fitfiles_path=Path("/x"),
+        )
+        assert profile.recalculate_calories is False
+        assert profile.weight_kg is None
+        assert profile.age is None
+        assert profile.sex is None
+
+    def test_profile_calorie_fields_set(self):
+        profile = Profile(
+            name="karoo",
+            app_type=AppType.CUSTOM,
+            garmin_username="u@x",
+            garmin_password="p",
+            fitfiles_path=Path("/x"),
+            recalculate_calories=True,
+            weight_kg=72.5,
+            age=34,
+            sex="female",
+        )
+        assert profile.recalculate_calories is True
+        assert profile.weight_kg == 72.5
+        assert profile.age == 34
+        assert profile.sex == "female"
+
+    def test_profile_legacy_dict_without_calorie_fields_uses_defaults(self):
+        """Old configs (no kcal keys) must still deserialize cleanly."""
+        legacy_dict = {
+            "name": "old",
+            "app_type": "zwift",
+            "garmin_username": "u@x",
+            "garmin_password": "p",
+            "fitfiles_path": "/x",
+        }
+        profile = Profile(**legacy_dict)
+        assert profile.recalculate_calories is False
+        assert profile.weight_kg is None
+
 
 class TestConfigMultiProfile:
     """Tests for Config multi-profile functionality."""
@@ -1260,6 +1304,50 @@ class TestProfileManager:
         profile = manager.get_profile("test")
         assert profile.garmin_username == "new@example.com"
 
+    def test_update_profile_explicit_none_clears_hr_inputs(self, manager):
+        """Test that passing None explicitly clears weight/age/sex."""
+        manager.create_profile(
+            "test",
+            AppType.ZWIFT,
+            "user@example.com",
+            "secret",
+            Path("/path"),
+            recalculate_calories=True,
+            weight_kg=75.0,
+            age=40,
+            sex="male",
+        )
+
+        manager.update_profile("test", weight_kg=None, age=None, sex=None)
+
+        profile = manager.get_profile("test")
+        assert profile.weight_kg is None
+        assert profile.age is None
+        assert profile.sex is None
+        # recalculate_calories was not passed, so it must be untouched
+        assert profile.recalculate_calories is True
+
+    def test_update_profile_omitted_hr_inputs_are_kept(self, manager):
+        """Test that omitting weight/age/sex leaves stored values untouched."""
+        manager.create_profile(
+            "test",
+            AppType.ZWIFT,
+            "user@example.com",
+            "secret",
+            Path("/path"),
+            recalculate_calories=True,
+            weight_kg=75.0,
+            age=40,
+            sex="male",
+        )
+
+        manager.update_profile("test", garmin_username="new@example.com")
+
+        profile = manager.get_profile("test")
+        assert profile.weight_kg == 75.0
+        assert profile.age == 40
+        assert profile.sex == "male"
+
     def test_update_profile_name(self, manager):
         """Test renaming a profile."""
         manager.create_profile(
@@ -1389,8 +1477,10 @@ class TestProfileManager:
         with pytest.raises(ValueError, match='Profile "nonexistent" not found'):
             manager.set_default_profile("nonexistent")
 
-    def test_display_profiles_table_with_profiles(self, manager, capsys):
+    def test_display_profiles_table_with_profiles(self, manager, capsys, monkeypatch):
         """Test display_profiles_table shows profiles in table format."""
+        # Widen the (non-tty) console so Rich doesn't truncate cell contents
+        monkeypatch.setenv("COLUMNS", "200")
         # Add a couple of profiles
         manager.create_profile(
             name="profile1",
@@ -1405,6 +1495,7 @@ class TestProfileManager:
             garmin_username="user2@example.com",
             garmin_password="pass2",
             fitfiles_path=Path("/path/to/fit2"),
+            recalculate_calories=True,
         )
         manager.set_default_profile("profile1")
 
@@ -1419,6 +1510,9 @@ class TestProfileManager:
         assert "⭐" in output  # Default profile marker
         assert "Zwift" in output
         assert "TPVirtual" in output  # Title case combined without spaces
+        assert "Kcal" in output  # Calorie recalculation column header
+        assert "✓" in output  # profile2 has recalculation enabled
+        assert "—" in output  # profile1 does not
 
     def test_display_profiles_table_empty(self, manager, capsys):
         """Test display_profiles_table with no profiles."""
@@ -1905,7 +1999,10 @@ class TestProfileManagerWizards:
 
         def mock_confirm(prompt, **kwargs):
             call_count["confirm"] += 1
-            # Confirm using detected directory
+            # Calorie recalculation step: keep this test focused on path/credentials.
+            if "calorie" in prompt.lower():
+                return MockQuestion(False)
+            # Confirm using detected directory and other prompts
             return MockQuestion(True)
 
         def mock_text(prompt, **kwargs):
@@ -2267,6 +2364,8 @@ class TestProfileManagerWizards:
             return MockQuestion(choices[0])
 
         def mock_confirm(prompt, **kwargs):
+            if "calorie" in prompt.lower():
+                return MockQuestion(False)
             return MockQuestion(True)
 
         def mock_text(prompt, **kwargs):
@@ -2402,6 +2501,101 @@ class TestProfileManagerWizards:
 
         captured = capsys.readouterr()
         assert "updated successfully" in captured.out
+
+    def test_edit_profile_wizard_removes_hr_inputs(
+        self, manager_with_profiles, monkeypatch, capsys
+    ):
+        """Answering No to keeping weight/age/sex clears them from the profile."""
+        manager_with_profiles.update_profile(
+            "profile1",
+            recalculate_calories=True,
+            weight_kg=75.0,
+            age=40,
+            sex="male",
+        )
+
+        def mock_select(prompt, choices, **kwargs):
+            return MockQuestion("profile1")
+
+        def mock_text(prompt, **kwargs):
+            return MockQuestion("")
+
+        def mock_password(prompt, **kwargs):
+            return MockQuestion("")
+
+        def mock_path(prompt, **kwargs):
+            return MockQuestion("")
+
+        def mock_confirm(prompt, **kwargs):
+            if "Edit calorie recalculation settings" in prompt:
+                return MockQuestion(True)
+            if "Enable calorie recalculation" in prompt:
+                return MockQuestion(True)
+            if "weight/age/sex" in prompt:
+                return MockQuestion(False)
+            return MockQuestion(False)
+
+        monkeypatch.setattr(questionary, "select", mock_select)
+        monkeypatch.setattr(questionary, "text", mock_text)
+        monkeypatch.setattr(questionary, "password", mock_password)
+        monkeypatch.setattr(questionary, "path", mock_path)
+        monkeypatch.setattr(questionary, "confirm", mock_confirm)
+
+        manager_with_profiles.edit_profile_wizard()
+
+        profile = manager_with_profiles.get_profile("profile1")
+        assert profile.recalculate_calories is True
+        assert profile.weight_kg is None
+        assert profile.age is None
+        assert profile.sex is None
+
+        captured = capsys.readouterr()
+        assert "updated successfully" in captured.out
+
+    def test_edit_profile_wizard_disable_calories_keeps_hr_inputs(
+        self, manager_with_profiles, monkeypatch, capsys
+    ):
+        """Disabling recalculation keeps stored weight/age/sex for later re-enable."""
+        manager_with_profiles.update_profile(
+            "profile1",
+            recalculate_calories=True,
+            weight_kg=75.0,
+            age=40,
+            sex="male",
+        )
+
+        def mock_select(prompt, choices, **kwargs):
+            return MockQuestion("profile1")
+
+        def mock_text(prompt, **kwargs):
+            return MockQuestion("")
+
+        def mock_password(prompt, **kwargs):
+            return MockQuestion("")
+
+        def mock_path(prompt, **kwargs):
+            return MockQuestion("")
+
+        def mock_confirm(prompt, **kwargs):
+            if "Edit calorie recalculation settings" in prompt:
+                return MockQuestion(True)
+            if "Enable calorie recalculation" in prompt:
+                return MockQuestion(False)
+            return MockQuestion(False)
+
+        monkeypatch.setattr(questionary, "select", mock_select)
+        monkeypatch.setattr(questionary, "text", mock_text)
+        monkeypatch.setattr(questionary, "password", mock_password)
+        monkeypatch.setattr(questionary, "path", mock_path)
+        monkeypatch.setattr(questionary, "confirm", mock_confirm)
+
+        manager_with_profiles.edit_profile_wizard()
+
+        profile = manager_with_profiles.get_profile("profile1")
+        assert profile.recalculate_calories is False
+        assert profile.weight_kg == 75.0
+        assert profile.age == 40
+        assert profile.sex == "male"
 
     def test_edit_profile_wizard_handles_error(
         self, manager_with_profiles, monkeypatch, capsys

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,6 +15,7 @@ from fit_file_faker.config import (
     ConfigManager,
     Profile,
     ProfileManager,
+    _validate_weight,
     get_fitfiles_path,
     get_tpv_folder,
     migrate_legacy_config,
@@ -825,6 +826,24 @@ class TestGetTpvFolder:
         # Should use environment variable, not ~/TPVirtual
         assert result == Path(test_path)
         assert result != Path.home() / "TPVirtual"
+
+
+class TestValidateWeight:
+    """Tests for the _validate_weight helper used by the calorie prompt."""
+
+    def test_accepts_valid_kg(self):
+        assert _validate_weight("70", "kg") is True
+
+    def test_accepts_valid_lbs(self):
+        # 154 lbs ≈ 69.9 kg, within the 20-300 kg plausible range.
+        assert _validate_weight("154", "lbs") is True
+
+    def test_rejects_non_numeric(self):
+        assert _validate_weight("not-a-number", "kg") is False
+
+    def test_rejects_out_of_range_kg(self):
+        assert _validate_weight("10", "kg") is False
+        assert _validate_weight("500", "kg") is False
 
 
 # ==============================================================================
@@ -2596,6 +2615,148 @@ class TestProfileManagerWizards:
         assert profile.weight_kg == 75.0
         assert profile.age == 40
         assert profile.sex == "male"
+
+    def test_edit_profile_wizard_sets_hr_inputs(
+        self, manager_with_profiles, monkeypatch, capsys
+    ):
+        """Providing weight/age/sex end-to-end stores the converted values."""
+
+        def mock_select(prompt, choices, **kwargs):
+            if "Weight unit" in prompt:
+                return MockQuestion("lbs")
+            if "Sex (for Keytel formula)" in prompt:
+                return MockQuestion("female")
+            return MockQuestion("profile1")
+
+        def mock_text(prompt, **kwargs):
+            if "Body weight" in prompt:
+                return MockQuestion("154")
+            if "Age (years)" in prompt:
+                return MockQuestion("35")
+            return MockQuestion("")
+
+        def mock_password(prompt, **kwargs):
+            return MockQuestion("")
+
+        def mock_path(prompt, **kwargs):
+            return MockQuestion("")
+
+        def mock_confirm(prompt, **kwargs):
+            if "Edit calorie recalculation settings" in prompt:
+                return MockQuestion(True)
+            if "Enable calorie recalculation" in prompt:
+                return MockQuestion(True)
+            if "weight/age/sex" in prompt:
+                return MockQuestion(True)
+            return MockQuestion(False)
+
+        monkeypatch.setattr(questionary, "select", mock_select)
+        monkeypatch.setattr(questionary, "text", mock_text)
+        monkeypatch.setattr(questionary, "password", mock_password)
+        monkeypatch.setattr(questionary, "path", mock_path)
+        monkeypatch.setattr(questionary, "confirm", mock_confirm)
+
+        manager_with_profiles.edit_profile_wizard()
+
+        profile = manager_with_profiles.get_profile("profile1")
+        assert profile.recalculate_calories is True
+        # 154 lbs -> ~69.9 kg
+        assert profile.weight_kg == pytest.approx(69.9, abs=0.1)
+        assert profile.age == 35
+        assert profile.sex == "female"
+
+    def test_edit_profile_wizard_cancels_weight_unit_prompt(
+        self, manager_with_profiles, monkeypatch, capsys
+    ):
+        """Cancelling the weight-unit prompt keeps existing HR inputs untouched."""
+        manager_with_profiles.update_profile(
+            "profile1",
+            recalculate_calories=True,
+            weight_kg=75.0,
+            age=40,
+            sex="male",
+        )
+
+        def mock_select(prompt, choices, **kwargs):
+            if "Weight unit" in prompt:
+                return MockQuestion(None)
+            return MockQuestion("profile1")
+
+        def mock_text(prompt, **kwargs):
+            return MockQuestion("")
+
+        def mock_password(prompt, **kwargs):
+            return MockQuestion("")
+
+        def mock_path(prompt, **kwargs):
+            return MockQuestion("")
+
+        def mock_confirm(prompt, **kwargs):
+            if "Edit calorie recalculation settings" in prompt:
+                return MockQuestion(True)
+            if "Enable calorie recalculation" in prompt:
+                return MockQuestion(True)
+            if "weight/age/sex" in prompt:
+                return MockQuestion(True)
+            return MockQuestion(False)
+
+        monkeypatch.setattr(questionary, "select", mock_select)
+        monkeypatch.setattr(questionary, "text", mock_text)
+        monkeypatch.setattr(questionary, "password", mock_password)
+        monkeypatch.setattr(questionary, "path", mock_path)
+        monkeypatch.setattr(questionary, "confirm", mock_confirm)
+
+        manager_with_profiles.edit_profile_wizard()
+
+        profile = manager_with_profiles.get_profile("profile1")
+        assert profile.weight_kg == 75.0
+        assert profile.age == 40
+        assert profile.sex == "male"
+
+    def test_edit_profile_wizard_cancels_age_prompt(
+        self, manager_with_profiles, monkeypatch, capsys
+    ):
+        """Cancelling the age prompt keeps the current age/sex but stores the new weight."""
+
+        def mock_select(prompt, choices, **kwargs):
+            if "Weight unit" in prompt:
+                return MockQuestion("kg")
+            return MockQuestion("profile1")
+
+        def mock_text(prompt, **kwargs):
+            if "Body weight" in prompt:
+                return MockQuestion("80")
+            if "Age (years)" in prompt:
+                return MockQuestion("")
+            return MockQuestion("")
+
+        def mock_password(prompt, **kwargs):
+            return MockQuestion("")
+
+        def mock_path(prompt, **kwargs):
+            return MockQuestion("")
+
+        def mock_confirm(prompt, **kwargs):
+            if "Edit calorie recalculation settings" in prompt:
+                return MockQuestion(True)
+            if "Enable calorie recalculation" in prompt:
+                return MockQuestion(True)
+            if "weight/age/sex" in prompt:
+                return MockQuestion(True)
+            return MockQuestion(False)
+
+        monkeypatch.setattr(questionary, "select", mock_select)
+        monkeypatch.setattr(questionary, "text", mock_text)
+        monkeypatch.setattr(questionary, "password", mock_password)
+        monkeypatch.setattr(questionary, "path", mock_path)
+        monkeypatch.setattr(questionary, "confirm", mock_confirm)
+
+        manager_with_profiles.edit_profile_wizard()
+
+        profile = manager_with_profiles.get_profile("profile1")
+        assert profile.weight_kg == 80.0
+        assert profile.age is None
+        assert profile.sex is None
 
     def test_edit_profile_wizard_handles_error(
         self, manager_with_profiles, monkeypatch, capsys

--- a/tests/test_fit_editor.py
+++ b/tests/test_fit_editor.py
@@ -2,6 +2,7 @@
 Tests for the FIT file editing functionality.
 """
 
+import logging
 from pathlib import Path
 
 import pytest
@@ -533,3 +534,53 @@ class TestCalorieRecalculation:
         editor.edit_fit(zwift_fit_parsed, output=output_file)
 
         assert self._session_total(output_file) == original_total
+
+    @pytest.mark.slow
+    def test_recalculation_skipped_logs_warning_when_method_none(
+        self, zwift_fit_parsed, temp_dir, monkeypatch, caplog
+    ):
+        """When there isn't enough data to estimate, a warning is logged."""
+        from fit_file_faker import calorie_calculator
+        from fit_file_faker.calorie_calculator import CalorieResult
+        from fit_file_faker.config import AppType, Profile
+
+        monkeypatch.setattr(
+            calorie_calculator,
+            "calculate_from_records",
+            lambda records, laps, profile: CalorieResult(
+                0, [], "none", "no power data and HR fallback inputs missing"
+            ),
+        )
+
+        profile = Profile(
+            name="zwift",
+            app_type=AppType.ZWIFT,
+            garmin_username="user@example.com",
+            garmin_password="pass",
+            fitfiles_path=Path("/path/to/files"),
+            recalculate_calories=True,
+        )
+        editor = FitEditor(profile=profile)
+        output_file = temp_dir / "zwift_kcal_skipped.fit"
+
+        with caplog.at_level(logging.WARNING):
+            editor.edit_fit(zwift_fit_parsed, output=output_file)
+
+        assert "Calorie recalculation requested but skipped" in caplog.text
+
+
+class TestInjectTotalCalories:
+    """Unit tests for the `_inject_total_calories` helper."""
+
+    def test_noop_when_field_not_present_on_message(self):
+        """A message whose definition never declared the field is left untouched."""
+        from fit_file_faker.fit_editor import _inject_total_calories
+
+        class FakeMessage:
+            def get_field(self, field_id):
+                return None
+
+        message = FakeMessage()
+        _inject_total_calories(message, 42)
+
+        assert not hasattr(message, "total_calories")

--- a/tests/test_fit_editor.py
+++ b/tests/test_fit_editor.py
@@ -459,3 +459,77 @@ class TestCustomDeviceSimulation:
                 break
 
         assert file_creator_found, "FileCreatorMessage not found in modified file"
+
+
+class TestCalorieRecalculation:
+    """End-to-end tests for the profile-driven calorie recalculation feature."""
+
+    @staticmethod
+    def _session_total(fit_path):
+        from fit_file_faker.vendor.fit_tool.profile.messages.session_message import (
+            SessionMessage,
+        )
+
+        modified = FitFile.from_file(str(fit_path))
+        for record in modified.records:
+            if isinstance(record.message, SessionMessage):
+                return record.message.total_calories
+        return None
+
+    @pytest.mark.slow
+    def test_karoo_gets_calories_added_when_enabled(self, karoo_fit_parsed, temp_dir):
+        """Karoo files miss `total_calories`; with the flag on we should fill it."""
+        from fit_file_faker.config import AppType, Profile
+
+        profile = Profile(
+            name="karoo",
+            app_type=AppType.CUSTOM,
+            garmin_username="user@example.com",
+            garmin_password="pass",
+            fitfiles_path=Path("/path/to/files"),
+            recalculate_calories=True,
+            weight_kg=75.0,
+            age=35,
+            sex="male",
+        )
+        editor = FitEditor(profile=profile)
+        output_file = temp_dir / "karoo_with_kcal.fit"
+
+        result = editor.edit_fit(karoo_fit_parsed, output=output_file)
+        assert result == output_file
+
+        total = self._session_total(output_file)
+        assert total is not None and total > 0, (
+            "Expected calorie recalculation to populate SessionMessage.total_calories"
+        )
+
+    @pytest.mark.slow
+    def test_existing_calories_not_overwritten(self, zwift_fit_parsed, temp_dir):
+        """If the source already has session calories, recalculation must not clobber it."""
+        from fit_file_faker.config import AppType, Profile
+        from fit_file_faker.vendor.fit_tool.profile.messages.session_message import (
+            SessionMessage,
+        )
+
+        original_total = None
+        for rec in zwift_fit_parsed.records:
+            if isinstance(rec.message, SessionMessage):
+                original_total = rec.message.total_calories
+                break
+        if not original_total:
+            pytest.skip("Zwift fixture has no existing session calories")
+
+        profile = Profile(
+            name="zwift",
+            app_type=AppType.ZWIFT,
+            garmin_username="user@example.com",
+            garmin_password="pass",
+            fitfiles_path=Path("/path/to/files"),
+            recalculate_calories=True,
+        )
+        editor = FitEditor(profile=profile)
+        output_file = temp_dir / "zwift_kcal_untouched.fit"
+
+        editor.edit_fit(zwift_fit_parsed, output=output_file)
+
+        assert self._session_total(output_file) == original_total


### PR DESCRIPTION
## Summary

Some devices — most notably the Hammerhead Karoo — don't write `total_calories` to their FIT files. After uploading, Garmin Connect shows the activity with 0 kcal, which also skews daily calorie totals and the nutrition module. This PR adds an opt-in, per-profile feature that estimates the missing value from data already recorded in the file and writes it into the Session and Lap messages.

Full transparency: this change was vibe-coded with Claude Code — but every part of it was reviewed, tested against real FIT files from my own rides, and the uploaded results were verified in Garmin Connect.

## How it works

A new `calorie_calculator.py` module supports two methods, in order of preference:

1. **Power-based** (used when at least 50% of records carry valid power data):
   integrates mechanical work from the power samples and converts kJ → kcal
   assuming 22% gross efficiency (`1 kJ ≈ 1.086 kcal`), the same convention
   used by Hammerhead, Garmin, and Strava. No personal data needed.
2. **HR-based fallback**: the Keytel et al. (2005) regression, which needs
   weight, age, and sex (stored in the profile, used for nothing else).

The estimation is defensive by design:

- **existing calorie values are never overwritten** — only missing ones are
  filled in,
- power is integrated trapezoidally (mean of the interval endpoints), which stays accurate for sparse "smart recording" samples,
- if the power meter drops out mid-ride, the affected samples fall back to the HR method (when weight/age/sex are configured) instead of counting zero work; the log message reports how many samples were filled this way,
- implausible samples are rejected (power > 2000 W, HR outside 30–230 bpm, FIT "invalid" markers),
- recording gaps are clamped to 30 s so pauses don't inflate the total,
- the session total is split across laps (samples falling between laps are attributed to the next lap to start), renormalized so the lap values sum up exactly to the session total,
- if neither method is applicable, the file is processed as before and a warning is logged.

Writing the value required a small workaround in `fit_editor.py`: when the source file's definition message doesn't include `total_calories`, the field is not growable in `fit_tool`, so the editor flips the flag and resets the cached definition so `FitFileBuilder(auto_define=True)` regenerates it.

## Configuration / UI

- New `Profile` fields: `recalculate_calories`, `weight_kg`, `age`, `sex` (all optional; existing configs load unchanged, no migration needed).
- New optional step in the profile creation wizard, plus full support in the edit wizard: values are pre-filled, Enter keeps them, and answering "No" to the weight/age/sex question removes them from the profile. Disabling the feature keeps the stored values so re-enabling doesn't ask for them again.
- The profiles table (`--list-profiles` / TUI) got a "Kcal est." column showing which profiles have the feature enabled.
- Weight can be entered in kg or lbs.

## Tests

- Full suite passing (324 tests); coverage for `config.py` and `app.py` stays at 100%.
- New `tests/test_calorie_calculator.py` (14 tests): power integration math, trapezoidal integration, single-sample and extended power dropouts (with and without HR data), HR fallback, method selection, gap clamping, per-lap split consistency including samples falling between or before laps.
- `tests/test_fit_editor.py`: end-to-end test on a real Karoo file (calories get injected and survive a rebuild/re-parse round trip) and a guard test proving existing calories are not touched (Zwift file).
- `tests/test_config.py`: new profile fields, legacy config compatibility, wizard flows including clearing anthropometric data, profiles table.

## Docs

- New "Calorie Estimation" section in the Multi-Profile Guide (motivation, both methods, dropout behaviour, config field reference) plus a new wizard step in the flow description and updated example config JSON.
- Short mention with a link in `README.md` / `docs/index.md`.
- `AGENTS.md` updated with the new module.